### PR TITLE
Fixed Honor Gain on Win / Loss of BG

### DIFF
--- a/src/game/BattleGroundAB.cpp
+++ b/src/game/BattleGroundAB.cpp
@@ -257,11 +257,15 @@ void BattleGroundAB::Update(uint32 diff)
             }
         }
 
-        // Test win condition
-        if (m_TeamScores[BG_TEAM_ALLIANCE] >= 2000)
+        // Reward Honor to winning team and End BG
+        if (m_TeamScores[BG_TEAM_ALLIANCE] >= 2000) {
+            BattleGround::RewardHonorToTeam(20, ALLIANCE);
             EndBattleGround(ALLIANCE);
-        if (m_TeamScores[BG_TEAM_HORDE] >= 2000)
+        }
+        if (m_TeamScores[BG_TEAM_HORDE] >= 2000) {
+            BattleGround::RewardHonorToTeam(20, HORDE);
             EndBattleGround(HORDE);
+        }
     }
 }
 

--- a/src/game/BattleGroundEY.cpp
+++ b/src/game/BattleGroundEY.cpp
@@ -37,6 +37,9 @@ uint32 BG_EY_HonorScoreTicks[BG_HONOR_MODE_NUM] = {
     200  // holiday
 };
 
+uint32 winningHonor = 40;
+uint32 losingHonor = 20;
+
 BattleGroundEY::BattleGroundEY()
 {
     m_BuffChange = true;
@@ -327,6 +330,17 @@ void BattleGroundEY::UpdateTeamScore(uint32 Team)
     if (score >= EY_MAX_TEAM_SCORE)
     {
         score = EY_MAX_TEAM_SCORE;
+
+        // Check faction and reward honor to winner / loser
+        if (Team == ALLIANCE) {
+            BattleGround::RewardHonorToTeam(winningHonor, ALLIANCE);
+            BattleGround::RewardHonorToTeam(losingHonor, HORDE);
+        }
+        else {
+            BattleGround::RewardHonorToTeam(winningHonor, HORDE);
+            BattleGround::RewardHonorToTeam(losingHonor, ALLIANCE);
+        }
+
         EndBattleGround(Team);
     }
 


### PR DESCRIPTION
Fixed issue with Winning and Losing honor gain for AB and EOTS battlegrounds.

They now correctly award the winner and losing teams with honor points.