### PR TITLE
Multiple Fixes (Info in Comments)

### DIFF
--- a/src/game/CharmInfo.cpp
+++ b/src/game/CharmInfo.cpp
@@ -337,10 +337,6 @@ void CharmInfo::HandleAttackCommand(uint64 targetGUID)
     if (!m_unit->canAttack(pTarget))
          return;
 
-    // Not let attack through obstructions
-    if (sWorld.getConfig(CONFIG_PET_LOS) && !m_unit->IsWithinLOSInMap(pTarget))
-        return;
-
     if (Creature* pCharm = m_unit->ToCreature())
     {
         pCharm->AI()->AttackStart(pTarget);

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -17829,6 +17829,31 @@ void Player::RestoreSpellMods(Spell const* spell)
     }
 }
 
+void Player::ResetSpellModsDueToCanceledSpell(Spell const* spell)
+{
+    for (int i = 0; i < MAX_SPELLMOD; ++i)
+    {
+        for (SpellModList::const_iterator itr = m_spellMods[i].begin(); itr != m_spellMods[i].end(); ++itr)
+        {
+            SpellModifier* mod = *itr;
+
+            if (mod->lastAffected != spell)
+                continue;
+
+            mod->lastAffected = nullptr;
+
+            if (mod->charges == -1)
+            {
+                mod->charges = 1;
+                if (m_SpellModRemoveCount > 0)
+                    --m_SpellModRemoveCount;
+            }
+            else if (mod->charges > 0)
+                ++mod->charges;
+        }
+    }
+}
+
 void Player::RemoveSpellMods(Spell const* spell)
 {
     if (!spell || (m_SpellModRemoveCount == 0))

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -1527,6 +1527,7 @@ class LOOKING4GROUP_EXPORT Player : public Unit
         template <class T> T ApplySpellMod(uint32 spellId, SpellModOp op, T &basevalue, Spell const* spell = NULL);
         void RemoveSpellMods(Spell const* spell);
         void RestoreSpellMods(Spell const* spell);
+        void ResetSpellModsDueToCanceledSpell(Spell const* spell);
 
         CooldownMgr& GetCooldownMgr() { return m_CooldownMgr; }
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3091,10 +3091,10 @@ void Spell::finish(bool ok)
 
     if (Player* modOwner = m_caster->GetSpellModOwner())
     {
-        if (ok || m_spellState != SPELL_STATE_PREPARING || m_spellState != SPELL_STATE_DELAYED)
+        if (ok || m_spellState != SPELL_STATE_PREPARING)
             modOwner->RemoveSpellMods(this);
         else
-            modOwner->RestoreSpellMods(this);
+            modOwner->ResetSpellModsDueToCanceledSpell(this);
     }
 
     m_spellState = SPELL_STATE_FINISHED;

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4942,6 +4942,9 @@ SpellCastResult Spell::CheckRange(bool strict)
     float min_range = SpellMgr::GetSpellMinRange(srange);
     uint32 range_type = SpellMgr::GetSpellRangeType(srange);
 
+    // Adding 15% Range Buffer
+    max_range *= 1.15f;
+
     if (Player* modOwner = m_caster->GetSpellModOwner())
         modOwner->ApplySpellMod(GetSpellInfo()->Id, SPELLMOD_RANGE, max_range, this);
 

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -1517,6 +1517,7 @@ void Unit::CalculateSpellDamageTaken(SpellDamageLog *damageInfo, int32 damage, S
     }
     else
         damage = 0;
+
     damageInfo->damage = damage;
 }
 
@@ -8461,6 +8462,19 @@ uint32 Unit::SpellDamageBonus(Unit *pVictim, SpellEntry const *spellProto, uint3
 
     if (GetObjectGuid().IsCreature())
         tmpDamage *= ((Creature*)this)->GetSpellDamageMod(((Creature*)this)->GetCreatureInfo()->rank);
+
+    // AoE Spell or Spell Radius not 0 and Target must be a pet!
+    if (((SpellMgr::IsAreaOfEffectSpell(spellProto)) || spellProto->EffectRadiusIndex[0] != 0) && ((Creature*)pVictim)->isPet()) {
+        // Pet has 25% damage avoidance buff
+        if (pVictim->HasAura(35694)) {
+            tmpDamage *= 0.75f;
+        }
+
+        // Pet has 50% damage avoidance buff or Felguard 50% avoidance
+        if (pVictim->HasAura(35698) || pVictim->HasAura(32233)) {
+            tmpDamage *= 0.5f;
+        }
+    }
 
     return tmpDamage > 0 ? uint32(tmpDamage) : 0;
 }

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -2305,6 +2305,11 @@ void Unit::RollMeleeHit(MeleeDamageLog *damageInfo, int32 crit_chance, int32 mis
         return;
     }
 
+    // Check if target is a totem, if so never miss/dodge/parry
+    if ( pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->isTotem()) {
+        return;
+    }
+
     int32 attackerMaxSkillValueForLevel = GetMaxSkillValueForLevel(pVictim);
     int32 victimMaxSkillValueForLevel = pVictim->GetMaxSkillValueForLevel(this);
 


### PR DESCRIPTION
6 Seperate Commits

Commit e2cf437 - Added 15% buffer to spell cast range, Trinity core had 25%, open to suggestion on this matter as 25% seems very large.

Commit 28df570 - Removed LoS check when telling pets to attack, they should pathfind. Ex : In arenas if someone is behind a pillar pet should pathfind to the unit.

Commit e85d358 - Fixed Avoidance spell for Hunter Pets and Felguards if they have the spell learned.

Commit 7f95cdc - Removed chance for a player to miss/dodge/parry an attack against a totem.

Commit 365c258 - Fixed the Weapon Skillup System. 

Commit 6a0475a - Fixed spells consuming spellmods if the spell was canceled. 



Credit to @robinsch and Nostalrius TBC for code / code references.