### PR TITLE
NIghtbane adds from 4 to 5

### DIFF
--- a/src/scripts/scripts/zone/karazhan/boss_nightbane.cpp
+++ b/src/scripts/scripts/zone/karazhan/boss_nightbane.cpp
@@ -407,7 +407,7 @@ struct boss_nightbaneAI : public ScriptedAI
             {
                 if (!Skeletons)
                 {
-                    for (uint8 i = 0; i <= 3; ++i)
+                    for (uint8 i = 0; i <= 4; ++i)
                     {
                         DoCast(m_creature->getVictim(), SPELL_SUMMON_SKELETON);
                     }


### PR DESCRIPTION
Very simple fix

https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2309/nightbane-adds

A few sources:

http://www.wowhead.com/npc=17225/nightbane#comments
"You have about 30 seconds, maybe a minute, to take down the **5 adds**."

http://wowwiki.wikia.com/wiki/Nightbane_(boss)
"Paladins are uniquely suited to this phase. A Paladin should activate his DPS cooldowns from trinkets and avenging wrath and tank the **5 skeletons**."

https://holylight.wordpress.com/2008/02/22/boss-tactics-nightbane/
"When he takes off into the air, a few things happen. Nightbane will cast “Rain of Bones” and you will get **5 non-elite skeletons** that need to be killed. They have about 13.5k health."