### PR TITLE
Nightbane: Charred Earth radius change

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3414,6 +3414,9 @@ void SpellMgr::LoadSpellCustomAttr()
             case 37936:
                 spellInfo->Attributes &= ~SPELL_ATTR_BREAKABLE_BY_DAMAGE;
                 break;
+            case 30129: // Nightbane: Charred Earth
+                spellInfo->EffectRadiusIndex[0] = 29;    // effect radius from 10 to 6 yd
+                break;
             case 37454: // Chess event: Bite
             case 37453: // Chess event: Smash
             case 37413: // Chess event: Visious Strike


### PR DESCRIPTION
https://bitbucket.org/Caboon/playcore-official/commits/025c260c53c5a7e9b4a2f499c590de42291b04c8
Effect is much larger than visual indication on live Hellfire server. This might be related to bad player hitboxes, in which case this should probably be re-tested after those are fixed. Or scrapped altogether.