### PR TITLE
Owner should be set in combat if pet attacks 

### DIFF
--- a/src/game/PetAI.cpp
+++ b/src/game/PetAI.cpp
@@ -311,6 +311,10 @@ void PetAI::UpdateAI(const uint32 diff)
 
             //targetHasCC = _CheckTargetCC(me->getVictim());
             // not required to be stopped case
+			
+			// Owner should be set in combat if pet attacks 
+			if (Unit* owner = me->GetOwner())
+			owner->SetInCombatWith(target);
 
             if (me->GetCurrentSpellId() != 6358 && !m_creature->hasUnitState(UNIT_STAT_CASTING))
                 DoMeleeAttackIfReady();

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -6870,19 +6870,12 @@ void Aura::HandleSchoolAbsorb(bool apply, bool Real)
             }
 
             DoneActualBenefit *= caster->CalculateLevelPenalty(GetSpellProto());
+
             m_modifier.m_amount += (int32)DoneActualBenefit;
-            
+
+            // apply threat equal to 1/2 healing threat for absorb value
             if (caster->GetTypeId() == TYPEID_PLAYER)
-            {
-                // bonus from Improved Power Word: Shield should be added after +healing bonus
-                uint32 impPWS[] = { 14769, 14768, 14748 };
-                uint32 talentId = caster->GetMaxRankSpellFromArray(impPWS, 2);
- 
-                if (Aura* spellModAura = caster->GetAura(talentId, 0))
-                m_modifier.m_amount *= (spellModAura->GetSpellProto()->EffectBasePoints[0] + 101.0f) / 100.0f; // basePoints = 14
-            }
-			// apply threat equal to 1/2 healing threat for absorb value
-			m_target->getHostilRefManager().threatAssist(caster, float(m_modifier.m_amount) * 0.25f, GetSpellProto());
+                m_target->getHostilRefManager().threatAssist(caster, float(m_modifier.m_amount) * 0.25f, GetSpellProto());
         }
     }
 }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -6870,12 +6870,19 @@ void Aura::HandleSchoolAbsorb(bool apply, bool Real)
             }
 
             DoneActualBenefit *= caster->CalculateLevelPenalty(GetSpellProto());
-
             m_modifier.m_amount += (int32)DoneActualBenefit;
-
-            // apply threat equal to 1/2 healing threat for absorb value
+            
             if (caster->GetTypeId() == TYPEID_PLAYER)
-                m_target->getHostilRefManager().threatAssist(caster, float(m_modifier.m_amount) * 0.25f, GetSpellProto());
+            {
+                // bonus from Improved Power Word: Shield should be added after +healing bonus
+                uint32 impPWS[] = { 14769, 14768, 14748 };
+                uint32 talentId = caster->GetMaxRankSpellFromArray(impPWS, 2);
+ 
+                if (Aura* spellModAura = caster->GetAura(talentId, 0))
+                m_modifier.m_amount *= (spellModAura->GetSpellProto()->EffectBasePoints[0] + 101.0f) / 100.0f; // basePoints = 14
+            }
+			// apply threat equal to 1/2 healing threat for absorb value
+			m_target->getHostilRefManager().threatAssist(caster, float(m_modifier.m_amount) * 0.25f, GetSpellProto());
         }
     }
 }

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -5003,7 +5003,7 @@ void Spell::EffectLearnPetSpell(uint32 i)
     pet->learnSpell(learn_spellproto->Id);
 
     pet->SavePetToDB(PET_SAVE_AS_CURRENT);
-    _player->PetSpellInitialize();
+    // _player->PetSpellInitialize(); -- action bar not removed at death and not required send at revive
 }
 
 void Spell::EffectTaunt(uint32 /*i*/)


### PR DESCRIPTION
https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2369/warlock-pet-and-combat

https://github.com/TrinityCore/TrinityCore/commit/1bbab51284d7517a2505eb15004779749726746f

But for 100% working this needs a update function because combat is dropped again after 5secs eventhough the pet is still hitting the target and is in combat with it, when player doesnt attack.