### PR TITLE
Double arena points for 7 weeks (Catchup Period)

### DIFF
--- a/src/game/ArenaTeam.cpp
+++ b/src/game/ArenaTeam.cpp
@@ -530,6 +530,9 @@ uint32 ArenaTeam::GetPoints(uint32 MemberRating)
     else
         points = 1511.26f / (1.0f + 1639.28f * exp(-0.00412f * (float)rating));
 
+    // 1.5x points for first 6 weeks
+    points = points * 2.0;
+        
     // type penalties for <5v5 teams
     if (Type == ARENA_TEAM_2v2)
         points *= 0.76f;


### PR DESCRIPTION
Adding double arena points for the next 7 Weeks. 

This will allow people to catch up, and be on par 7 weeks from now, which is about when T5 will be released.

We should be on schedule.