### PR TITLE
Fixed : DoT and Faerie fire now both properly remove stealth 

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -1167,8 +1167,21 @@ void Spell::DoSpellHitOnUnit(Unit *unit, const uint32 effectMask)
                 return;
             }
 
+            // Make unit stand on spell hit
             if (!unit->IsStandState() && !unit->hasUnitState(UNIT_STAT_STUNNED))
                     unit->SetStandState(UNIT_STAND_STATE_STAND);
+
+            // Fearie fire break stealth
+            if(GetSpellInfo()->Id == 770 || GetSpellInfo()->Id == 778 || GetSpellInfo()->Id == 9749 || GetSpellInfo()->Id == 9907) {
+                unit->RemoveAuraTypeByCaster(SPELL_AURA_MOD_STEALTH, unit->GetGUID());
+            }
+
+            // DOT break stealth on application
+            for (int j=0; j<3; j++) {
+                if (GetSpellInfo()->EffectApplyAuraName[j] == SPELL_AURA_PERIODIC_DAMAGE) {
+                    unit->RemoveAuraTypeByCaster(SPELL_AURA_MOD_STEALTH, unit->GetGUID());
+                }
+            }
 
             unit->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_HITBYSPELL);
             if (GetSpellInfo()->AttributesCu & SPELL_ATTR_CU_AURA_CC)

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3657,6 +3657,10 @@ void SpellMgr::LoadSpellCustomAttr()
             case 29476: // Astral Armor Curator Physical school
                 spellInfo->SchoolMask = 1;
                 break;
+            case 33671: // Gruul Shatter Radius Reduction (From 20 to 19 yards)
+                // There was a slight range issue with shatter
+                spellInfo->EffectRadiusIndex[0] = 49;
+                break;
             default:
                 break;
         }

--- a/src/game/Totem.cpp
+++ b/src/game/Totem.cpp
@@ -106,6 +106,10 @@ void Totem::Summon(Unit* owner)
         default: break;
     }
 
+    // Tremor cast on summon
+    if(GetEntry() == TREMOR_TOTEM_ENTRY)
+        CastSpell(this, 8146, false);
+
     if (GetEntry() == SENTRY_TOTEM_ENTRY)
         SetReactState(REACT_AGGRESSIVE);
 

--- a/src/game/Totem.h
+++ b/src/game/Totem.h
@@ -31,6 +31,7 @@ enum TotemType
 };
 
 #define SENTRY_TOTEM_ENTRY  3968
+#define TREMOR_TOTEM_ENTRY 5913
 
 class Totem : public Creature
 {


### PR DESCRIPTION
All DoT and Faerie fire will now remove stealth on their application.

DoT would only happen on first tick,

Faerie fire wouldnt let you RE-stealth, however it would allow you to stay stealthed until knocked out.