### PR TITLE
Blast nova should happen every 60 seconds

### DIFF
--- a/src/scripts/scripts/zone/hellfire_citadel/magtheridons_lair/boss_magtheridon.cpp
+++ b/src/scripts/scripts/zone/hellfire_citadel/magtheridons_lair/boss_magtheridon.cpp
@@ -159,7 +159,7 @@ struct boss_magtheridonAI : public BossAI
         instance->SetData(DATA_MAGTHERIDON_EVENT, NOT_STARTED);
 
         events.ScheduleEvent(MAGTHERIDON_EVENT_BERSERK, 1320000);
-        events.ScheduleEvent(MAGTHERIDON_EVENT_BLAST_NOVA, urand(50000, 60000));
+        events.ScheduleEvent(MAGTHERIDON_EVENT_BLAST_NOVA, 60000);
         events.ScheduleEvent(MAGTHERIDON_EVENT_BLAZE, urand(10000, 30000));
         events.ScheduleEvent(MAGTHERIDON_EVENT_CLEAVE, 15000);
         events.ScheduleEvent(MAGTHERIDON_EVENT_QUAKE, 40000);
@@ -271,7 +271,7 @@ struct boss_magtheridonAI : public BossAI
                 case MAGTHERIDON_EVENT_BLAST_NOVA:
                 {
                     AddSpellToCastWithScriptText(SPELL_BLASTNOVA, CAST_NULL, MAGTHERIDON_EMOTE_BLASTNOVA);
-                    events.ScheduleEvent(MAGTHERIDON_EVENT_BLAST_NOVA, urand(50000, 60000));
+                    events.ScheduleEvent(MAGTHERIDON_EVENT_BLAST_NOVA, 60000);
                     break;
                 }
                 case MAGTHERIDON_EVENT_BLAZE:


### PR DESCRIPTION
Currently happens at a random interval between 50 and 60 seconds from the last cast. Should be on a strict 60 second cooldown.
http://wow.gamepedia.com/Magtheridon_(tactics)
https://bitbucket.org/Caboon/playtbc_core/src/05e4fbc7b00e8802300761f8b3bae2a78f621bb7/src/scripts/Outland/HellfireCitadel/magtheridons_lair/boss_magtheridon.cpp?fileviewer=file-view-default#boss_magtheridon.cpp-247