### PR TITLE
Updated polymorph init and recast timers.

### DIFF
--- a/src/scripts/scripts/zone/gruuls_lair/boss_high_king_maulgar.cpp
+++ b/src/scripts/scripts/zone/gruuls_lair/boss_high_king_maulgar.cpp
@@ -302,7 +302,7 @@ struct boss_kiggler_the_crazedAI : public BossAI
         events.Reset();
         ClearCastQueue();
 
-        events.ScheduleEvent(EVENT_POLYMORPH, 5000);
+        events.ScheduleEvent(EVENT_POLYMORPH, urand(10000, 25000)); //Probably too quick
         events.ScheduleEvent(EVENT_ARCANE_SHOCK, 20000);
         events.ScheduleEvent(EVENT_ARCANE_EXPLO, 30000);
 
@@ -343,7 +343,7 @@ struct boss_kiggler_the_crazedAI : public BossAI
                 case EVENT_POLYMORPH:
                 {
                     AddSpellToCast(SPELL_GREATER_POLYMORPH, CAST_RANDOM);
-                    events.ScheduleEvent(eventId, 20000);
+                    events.ScheduleEvent(eventId, urand(10000, 25000));
                     break;
                 }
                 case EVENT_ARCANE_SHOCK:


### PR DESCRIPTION
https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2549/greater-polymorph-kiggler-the-crazed

The proposed recast timer from the report seems reasonable, although it is possible that it should be between 10 and 20 seconds rather than 10 and 25.

As for the init timer.. It should most likely be longer than the recast timer, but due to a lack of evidence I've set it to the same as the recast timer. Instead of the old value of 5 seconds, which I can not find support of anywhere.

The report also mentions that polymorphs are supposed to only be cast at the primary target, I have only touched the timers.