### PR TITLE
Update serpent_shrine_trash.cpp

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/serpent_shrine_trash.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/serpent_shrine_trash.cpp
@@ -231,7 +231,7 @@ struct mob_underbog_colossusAI : public ScriptedAI
             entry = NPC_COLOSSUS_LURKER;
             break;
         case 3:
-            count = urand(8, 10);
+            count = urand(10, 15);
             entry = NPC_COLOSSUS_RAGER;
             break;
         case 4:


### PR DESCRIPTION
http://www.wowhead.com/npc=22352/colossus-rager#comments

By Blais (210 – 1·1) on 2007/04/12 (Patch 2.0.12)		
10-15 of these have a chance to spawn after killing a Underbog Colussus. They have tons of HP making it so they can't be aoed.