### PR TITLE
Update boss_lady_vashj.cpp

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
@@ -49,7 +49,7 @@ EndScriptData */
 #define SPELL_STATIC_CHARGE_TRIGGER 38280
 #define SPELL_FORKED_LIGHTNING      40088
 #define SPELL_SHOOT                 40873
-#define SPELL_POISON_BOLT           40095
+#define SPELL_POISON_BOLT           38253
 #define SPELL_TOXIC_SPORES          38575
 #define SPELL_MAGIC_BARRIER         38112
 #define SPELL_PARALYZE              38132
@@ -778,7 +778,7 @@ struct mob_tainted_elementalAI : public Scripted_NoMovementAI
     void Reset()
     {
         PoisonBolt_Timer = 5000+rand()%5000;
-        Despawn_Timer = 16000;
+        Despawn_Timer = 15000;
     }
 
     void JustDied(Unit *killer)

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
@@ -49,7 +49,7 @@ EndScriptData */
 #define SPELL_STATIC_CHARGE_TRIGGER 38280
 #define SPELL_FORKED_LIGHTNING      40088
 #define SPELL_SHOOT                 40873
-#define SPELL_POISON_BOLT           38253
+#define SPELL_POISON_BOLT           40095   // 38253
 #define SPELL_TOXIC_SPORES          38575
 #define SPELL_MAGIC_BARRIER         38112
 #define SPELL_PARALYZE              38132


### PR DESCRIPTION
http://www.wowhead.com/npc=22009/tainted-elemental#abilities

http://looking4group.de/quelthalas/database/?spell=38253 , http://looking4group.de/quelthalas/database/?spell=40095

Didnt Check whether Spell is functional!

http://www.wowhead.com/npc=22009/tainted-elemental#comments

http://us.battle.net/wow/en/forum/topic/8874287874

By dJe781 (7,795 – 1·19·62) on 2007/06/12 (Patch 2.1.1)		
Tainted Elementals drop Tainted Core which must be used against Vashj to bring her immune shield down during phase 2. A Tainted Elementals pops every 50 seconds and must be killed in roughly 15 seconds, if you don't, it depops.

It got nerfed so they stay up much longer than 15 seconds.