### PR TITLE
Update boss_lady_vashj.cpp

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
@@ -891,7 +891,7 @@ struct mob_toxic_sporebatAI : public ScriptedAI
 
                 Unit *tar = ((boss_lady_vashjAI*)((Creature*)Vashj)->AI())->SelectUnit(SELECT_TARGET_RANDOM,0,300,true);
                 if (tar)
-                    if (Creature *tempsum = tar->SummonCreature(TOXIC_SPORES_TRIGGER,tar->GetPositionX(), tar->GetPositionY(), tar->GetPositionZ(),0,TEMPSUMMON_TIMED_DESPAWN, 30000))
+                    if (Creature *tempsum = tar->SummonCreature(TOXIC_SPORES_TRIGGER,tar->GetPositionX(), tar->GetPositionY(), tar->GetPositionZ(),0,TEMPSUMMON_TIMED_DESPAWN, urand(60000, 120000)))
                     {   
                         tempsum->setFaction(14); 
                         tempsum->CastSpell(tar, SPELL_TOXIC_SPORES,true);


### PR DESCRIPTION
Making Spell http://www.wowhead.com/spell=38574/toxic-spores#summons spawned Spore drop trigger http://www.wowhead.com/npc=22207/spore-drop-trigger last longer than the "visual" 30secs despawn time as this was never the case on prenerf blizzlike lady vashj fights.

The Room was completly covered in Toxic Spores when Phase 3 lasted too long.

http://wowwiki.wikia.com/wiki/Lady_Vashj_(tactics)

Toxic Spores - Poison cloud AoE 1,500 nature damage per second [No Despawn]

http://www.ownedcore.com/forums/world-of-warcraft/world-of-warcraft-guides/95377-guilds-stuck-lady-vashj-starting-her.html

The MT has to be continuously moving Vashj on the outside of the room so that the melee DPS and himself/herself won't die from a toxic spore spawn. If you can survive phase 2 with about 22 people up, you should have enough DPS to burn Vashj down before the room becomes covered in toxic spores. [No Despawn]

http://www.rarguild.com/wiki/index.php?title=Lady_Vashj&diff=2136&oldid=2135 [Duration 30 sec]

If the despawntimer stays the same the sporebat timer has to be changed to a more realistic value.

http://thecore-echo.tripod.com/lady_vashj.htm

Or if no enrage implementation so:

This phase is a DPS race since the rate of which Toxic Coulds spawn is greatly increased after 4 minutes.

http://www.tentonhammer.com/guides/serpentshrine-cavern-guide-lady-vashj

The spore bats start flying into the room at a slow pace and then multiple quickly as the fight goes on. The spore bats circle the room dropping toxic spores on the ground that create poison clouds where they land that do roughly 1,500 damage per second to anyone in them. The clouds last a while and eventually will fill up most of the room in patches. At least initially the bats can be thinned out by having 2-3 players (Hunters, Warlocks, Shadow Priests, Mages all work well) stand at the west stairs and hit them and dot them as they enter. In this way you have less of them to deal with throughout this phase.

After a while though (about 5 - 6 minutes) there will be so many bats that moving becomes very treacherous and players start dieing due to movement alone. This is a sort of encounter timer. Your goal is to down Lady Vashj before this time.

Enjoy the encounter and if you have gotten into phase 3, it is just a matter of time before you complete the encounter successfully.

I personally suggest mixxing those two things increase duration to 60000-120000 and rapidly increase spawnrate at 240000secs into phase 3.