### PR TITLE
Update boss_midnight.cpp

### DIFF
--- a/src/scripts/scripts/zone/karazhan/boss_midnight.cpp
+++ b/src/scripts/scripts/zone/karazhan/boss_midnight.cpp
@@ -299,7 +299,7 @@ struct boss_attumenAI : public ScriptedAI
         {
             if (ChargeTimer < diff)
             {
-                if (Unit * target = SelectUnit(SELECT_TARGET_RANDOM, 0, 100.0f, true, 0, 5.0f))
+                if (Unit * target = SelectUnit(SELECT_TARGET_FARTHEST, 0, 100.0f, true, 0, 5.0f))
                     AddSpellToCast(target, SPELL_BERSERKER_CHARGE);
 
                 ChargeTimer = 20000;


### PR DESCRIPTION
Give raids more control over first boss ability berserker charge, spellid=26561.

https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2277/attumen-phase-3-charge

http://karaguide.blogspot.de/2007/07/attumenmidnight.html

http://www.wowhead.com/npc=16152/attumen-the-huntsman#comments

"He randomly charges the person farthest"