### PR TITLE
Implement server side support for Gladdy addon

### DIFF
--- a/src/game/BattleGround.cpp
+++ b/src/game/BattleGround.cpp
@@ -1097,6 +1097,13 @@ void BattleGround::StartBattleGround()
     AnnounceBGStart();
     if (m_IsRated)
         sLog.outLog(LOG_ARENA, "Arena match type: %u for Team1Id: %u - Team2Id: %u started.", m_ArenaType, m_ArenaTeamIds[BG_TEAM_ALLIANCE], m_ArenaTeamIds[BG_TEAM_HORDE]);
+	
+	/* Send message to Gladdy addon to prevent it from greying out! */
+	for (BattleGroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr){
+         if (Player *plr = sObjectMgr.GetPlayer(itr->first)){
+             plr->BuildGladdyUpdate();
+		 }
+	}
 }
 
 void BattleGround::AnnounceBGStart()

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -17,7 +17,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-
 #include "Common.h"
 #include "Language.h"
 #include "Database/DatabaseEnv.h"
@@ -71,6 +70,7 @@
 
 #include <cmath>
 #include <cctype>
+#include <iomanip>
 
 #define ZONE_UPDATE_INTERVAL 1000
 
@@ -22466,6 +22466,166 @@ Unit* Player::GetNearBossInCombat()
     }
     return NULL;
 }
+
+/* Addon Helper START */
+
+void Player::SendAddonMessage(std::string& text, char* prefix)
+ {
+     std::string message;
+     message.append(prefix);
+     message.push_back(9);
+     message.append(text);
+ 
+     WorldPacket data(SMSG_MESSAGECHAT, 200);
+     data << uint8(CHAT_MSG_WHISPER);
+     data << uint32(LANG_ADDON);
+     data << uint64(0); // guid
+     data << uint32(LANG_ADDON);                               //language 2.1.0 ?
+     data << uint64(0); // guid
+     data << uint32(message.length() + 1);
+     data << message;
+     data << uint8(0);
+	 BroadcastPacketInRange(&data, MAX_VISIBILITY_DISTANCE, false, false);
+ }
+
+char *GetClassString(uint8 _Class)
+ {
+     switch (_Class)
+     {
+         case CLASS_WARRIOR: return "WARRIOR"; break;
+         case CLASS_PALADIN: return "PALADIN"; break;
+         case CLASS_HUNTER:  return "HUNTER";  break;
+         case CLASS_ROGUE:   return "ROGUE";   break;
+         case CLASS_PRIEST:  return "PRIEST";  break;
+         case CLASS_SHAMAN:  return "SHAMAN";  break;
+         case CLASS_MAGE:    return "MAGE";    break;
+         case CLASS_WARLOCK: return "WARLOCK"; break;
+         case CLASS_DRUID:   return "DRUID";   break;
+         default: return ""; break;
+     }
+ }
+ 
+ char *GetClassLocalString(uint8 _Class)
+ {
+     switch (_Class)
+     {
+         case CLASS_WARRIOR: return "Warrior"; break;
+         case CLASS_PALADIN: return "Paladin"; break;
+         case CLASS_HUNTER:  return "Hunter";  break;
+         case CLASS_ROGUE:   return "Rogue";   break;
+         case CLASS_PRIEST:  return "Priest";  break;
+         case CLASS_SHAMAN:  return "Shaman";  break;
+         case CLASS_MAGE:    return "Mage";    break;
+         case CLASS_WARLOCK: return "Warlock"; break;
+         case CLASS_DRUID:   return "Druid";   break;
+         default: return ""; break;
+     }
+ }
+ 
+ char *GetRaceLocalString(uint8 _Race)
+ {
+     switch (_Race)
+     {
+         case RACE_HUMAN:         return "Human";    break;
+         case RACE_ORC:           return "Orc";      break;
+         case RACE_DWARF:         return "Dwarf";    break;
+         case RACE_NIGHTELF:      return "Nightelf"; break;
+         case RACE_UNDEAD_PLAYER: return "Undead";   break;
+         case RACE_TAUREN:        return "Tauren";   break;
+         case RACE_GNOME:         return "Gnome";    break;
+         case RACE_TROLL:         return "Troll";    break;
+         case RACE_BLOODELF:      return "Bloodelf"; break;
+         case RACE_DRAENEI:       return "Draenei";  break;
+         default: return ""; break;
+     }
+ }
+ 
+ class GladdyUpdate
+ {
+ public:
+     std::string msg;
+      
+     GladdyUpdate(Player *p)
+     {
+         msg = "";
+         msg.append(p->GetName());
+         msg.push_back(',');
+     }
+ 
+     void AppendGUID(uint64 unitGUID)
+     {
+         std::stringstream sstream;
+         sstream << "0x" << std::setfill('0') << std::setw(sizeof(uint64) * 2) << std::hex << unitGUID;
+         msg.append(sstream.str());
+         msg.push_back(',');
+     }
+      
+     void Append(uint32 data)
+     {
+         std::ostringstream os;
+         os << data;
+         msg.append(os.str());
+         msg.push_back(',');
+     }
+ 
+     void AppendChar(char* prefix)
+     {
+         msg.append(prefix);
+         msg.push_back(',');
+     }
+ 
+     void AppendLast(uint32 data)
+     {
+         std::ostringstream os;
+         os << data;
+         msg.append(os.str());
+     }
+ };
+      
+ void Player::BuildGladdyUpdate()
+ {
+     if (!InArena() || GetBattleGround()->GetStatus() != STATUS_IN_PROGRESS)
+         return;
+ 
+     Powers type = getPowerType();
+     int32 maxPower;
+     int32 currentPower;
+     if (type == POWER_RAGE)
+     {
+         currentPower = GetPower(type) / 10;
+         maxPower = GetMaxPower(type) / 10;
+     }
+     else
+     {
+         currentPower = GetPower(type);
+         maxPower = GetMaxPower(type);
+     }
+      
+     GladdyUpdate update(this);
+     update.AppendGUID(GetGUID());
+     update.AppendChar(GetClassString(getClass())); // class
+     update.AppendChar(GetClassLocalString(getClass())); // locclass
+     update.AppendChar(GetRaceLocalString(getRace())); // locrace
+     update.AppendChar(""); // correct
+     update.Append(GetHealth());
+     update.Append(GetMaxHealth());
+     update.Append(currentPower);
+     update.Append(maxPower);
+     update.AppendLast(type);
+      
+     SendAddonMessage(update.msg, "Gladdy");
+ }
+ 
+ void Player::SendGladdyNotification()
+ {
+     std::stringstream sstream;
+     sstream << "0x" << std::setfill('0') << std::setw(sizeof(uint64) * 2) << std::hex << std::uppercase << GetGUID();
+     std::string result = sstream.str();
+ 
+     SendAddonMessage(result, "GladdyTrinketUsed");
+ } 
+
+ /* Addon Helper FINISH */
 
 void Player::_LoadInstanceTimeRestrictions(QueryResultAutoPtr result)
 {

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -22555,7 +22555,7 @@ char *GetClassString(uint8 _Class)
      void AppendGUID(uint64 unitGUID)
      {
          std::stringstream sstream;
-         sstream << "0x" << std::setfill('0') << std::setw(sizeof(uint64) * 2) << std::hex << unitGUID;
+         sstream << "0x" << std::setfill('0') << std::setw(sizeof(uint64) * 2) << std::hex << std::uppercase << unitGUID;
          msg.append(sstream.str());
          msg.push_back(',');
      }

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -1918,6 +1918,12 @@ class LOOKING4GROUP_EXPORT Player : public Unit
 	 void PvpPush(uint16 items[]); //Funktionsdeklaration für S0,5
 	 void AddItem(uint32 itemID, uint32 Count);
 
+	 /* Addon Helper functions */
+	 void SendMessageToSetInRange(WorldPacket *data, float dist, bool self, bool own_team_only);
+	 void SendAddonMessage(std::string& text, char* prefix);
+	 void BuildGladdyUpdate();
+	 void SendGladdyNotification();
+
         /*********************************************************/
         /***               BATTLEGROUND SYSTEM                 ***/
         /*********************************************************/

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -1919,7 +1919,6 @@ class LOOKING4GROUP_EXPORT Player : public Unit
 	 void AddItem(uint32 itemID, uint32 Count);
 
 	 /* Addon Helper functions */
-	 void SendMessageToSetInRange(WorldPacket *data, float dist, bool self, bool own_team_only);
 	 void SendAddonMessage(std::string& text, char* prefix);
 	 void BuildGladdyUpdate();
 	 void SendGladdyNotification();

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2481,6 +2481,11 @@ void Spell::cancel()
 
 void Spell::cast(bool skipCheck)
 {
+	// send trinket message to Gladdy
+	if (m_spellInfo->Id == 42292){
+		m_caster->ToPlayer()->SendGladdyNotification();
+	}
+
     // what the fuck is done here? o.O
     SpellEntry const* spellInfo = sSpellStore.LookupEntry(GetSpellInfo()->Id);
     if (!spellInfo)


### PR DESCRIPTION
I ported this this morning, after getting the idea because I saw that deathside were looking to implement this. I had previously researched the commits in TBCPvP (by robinsch) and talked to Cola in 2014 about a way I could do this. Back then, I was using the Player::Yell function - this time I'm doing it right (I hope).

Unfortunately, I haven't been able to test this, because I can't log into my local server (getting disconnected after "Connected"). 

It compiles without errors and it should work just fine, however until given the opportunity to analyze messages ingame, I cannot test it. 

Gladdy requires messages of type whisper. This may or may be bugged, because BroadCastPacketInRange is not a regular whisper. If you merge this and put it on a test realm, I'd be happy to make sure it works and fix it, if it doesn't.
https://github.com/Schaka/gladdy/blob/master/Gladdy.lua#L769