### PR TITLE
Revert "Double arena points for 7 weeks (Catchup Period)" 

### DIFF
--- a/src/game/ArenaTeam.cpp
+++ b/src/game/ArenaTeam.cpp
@@ -530,9 +530,6 @@ uint32 ArenaTeam::GetPoints(uint32 MemberRating)
     else
         points = 1511.26f / (1.0f + 1639.28f * exp(-0.00412f * (float)rating));
 
-    // 1.5x points for first 6 weeks
-    points = points * 2.0;
-        
     // type penalties for <5v5 teams
     if (Type == ARENA_TEAM_2v2)
         points *= 0.76f;


### PR DESCRIPTION
Reverts Looking4Group/L4G_Core#45

Revert on 08.08.16, just for info so it is not forgotten.