### PR TITLE
Updated timer for Tito's summon

### DIFF
--- a/src/scripts/scripts/zone/karazhan/bosses_opera.cpp
+++ b/src/scripts/scripts/zone/karazhan/bosses_opera.cpp
@@ -215,7 +215,7 @@ struct boss_dorotheeAI : public boss_operaAI
 
         WaterBoltTimer = 5000;
         FearTimer = 15000;
-        SummonTitoTimer = 47500;
+        SummonTitoTimer = urand(36000,41000);
 
         SummonedTito = false;
         TitoDied = false;


### PR DESCRIPTION
https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2603/dorothy-does-not-summon-tito

Last reply provides sources indicating that the timer is supposed to be a random interval that includes 37 and 40. This commit sets the interval to 36-41, as it is hard to pinpoint the exact time the spell is cast. Only having 2 samples is also not optimal, the interval should possibly be larger (in both directions, or just one).