### PR TITLE
Update boss_tailonking_ikiss.cpp

### DIFF
--- a/src/scripts/scripts/zone/aunchindoun/sethekk_halls/boss_tailonking_ikiss.cpp
+++ b/src/scripts/scripts/zone/aunchindoun/sethekk_halls/boss_tailonking_ikiss.cpp
@@ -77,10 +77,10 @@ struct boss_talon_king_ikissAI : public ScriptedAI
     {
         HeroicMode = m_creature->GetMap()->IsHeroic();
 
-        ArcaneVolley_Timer = 5000;
+        ArcaneVolley_Timer = urand(5000, 12000);
         Sheep_Timer = 8000;
-        Blink_Timer = 35000;
-        Slow_Timer = 15000+rand()%15000;
+        Blink_Timer = urand(16000, 20000);
+        Slow_Timer = urand(9000, 13000);
         Blink = false;
         Intro = false;
         ManaShield = false;
@@ -147,7 +147,7 @@ struct boss_talon_king_ikissAI : public ScriptedAI
         if (ArcaneVolley_Timer < diff)
         {
             DoCast(m_creature,HeroicMode ? H_SPELL_ARCANE_VOLLEY : SPELL_ARCANE_VOLLEY);
-            ArcaneVolley_Timer = 10000+rand()%5000;
+            ArcaneVolley_Timer = urand(8000, 12000);
         }
         else
             ArcaneVolley_Timer -= diff;
@@ -175,7 +175,7 @@ struct boss_talon_king_ikissAI : public ScriptedAI
             if (Slow_Timer < diff)
             {
                 DoCast(m_creature,H_SPELL_SLOW);
-                Slow_Timer = 15000+rand()%25000;
+                Slow_Timer = urand(15000, 24000);
             }
             else
                 Slow_Timer -= diff;
@@ -198,7 +198,7 @@ struct boss_talon_king_ikissAI : public ScriptedAI
                 DoCast(target,SPELL_BLINK_TELEPORT);
                 Blink = true;
             }
-            Blink_Timer = 35000+rand()%5000;
+            Blink_Timer = 15000+rand()%25000;
         }
         else
             Blink_Timer -= diff;


### PR DESCRIPTION
https://github.com/cmangos/mangos-tbc/blob/master/src/scriptdev2/scripts/outland/auchindoun/sethekk_halls/boss_talon_king_ikiss.cpp

https://github.com/NostalriusTBC/Core/blob/master/src/scriptdev2/scripts/outland/auchindoun/sethekk_halls/boss_talon_king_ikiss.cpp

https://github.com/OregonCore/OregonCore/blob/master/src/scripts/Outland/Auchindoun/sethekk_halls/boss_tailonking_ikiss.cpp

http://wowwiki.wikia.com/wiki/Talon_King_Ikiss?direction=next&oldid=514381

As of Feb. 23 2007, he now has a fairly high chance to chain blink and cast his explosion repeatedly. (5sec casttime) This means that if your party members are hiding behind a pillar when he casts arcane explosion, he may blink behind that pillar and begin casting it again. A GM has confirmed that this is an intended change.

This was later nerfed to flat % HP Values.