### PR TITLE
Update boss_lady_vashj_CoilfangElite_Timer.cpp

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
@@ -609,7 +609,7 @@ struct boss_lady_vashjAI : public ScriptedAI
             {
                 path_nr = urand(0,3);
                 me->SummonCreature(COILFANG_ELITE, StriderNagaWP[path_nr*4][0],StriderNagaWP[path_nr*4][1],StriderNagaWP[path_nr*4][2],0, TEMPSUMMON_DEAD_DESPAWN, 0);
-                CoilfangElite_Timer = 50000+rand()%5000;
+                CoilfangElite_Timer = 45000+rand()%5000;
             }
             else
                 CoilfangElite_Timer -= diff;


### PR DESCRIPTION
http://wowwiki.wikia.com/wiki/Lady_Vashj_(tactics)?direction=next&oldid=882757

About every 45 seconds into the fight a Coilfang Elite will spawn.

A new Elite will spawn somewhere in the room after another 45 seconds.