### PR TITLE
Update boss_temporus.cpp

### DIFF
--- a/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
+++ b/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
@@ -47,7 +47,6 @@ struct boss_temporusAI : public ScriptedAI
 
     ScriptedInstance *pInstance;
     bool HeroicMode;
-    //bool canApplyWound;
 
     uint32 MortalWound_Timer;
     uint32 WingBuffet_Timer;
@@ -57,7 +56,6 @@ struct boss_temporusAI : public ScriptedAI
     void Reset()
     {
         MortalWound_Timer = 8000;
-        //canApplyWound = false;
         WingBuffet_Timer = 10000;
         Haste_Timer = urand(15000, 23000);
         SpellReflection_Timer = 30000;
@@ -106,14 +104,6 @@ struct boss_temporusAI : public ScriptedAI
         ScriptedAI::MoveInLineOfSight(who);
     }
 
-    void DamageMade(Unit* target, uint32 & damage, bool direct_damage)
-    {
-        //if (canApplyWound)
-            me->CastSpell(target, SPELL_MORTAL_WOUND, true);
-
-        //canApplyWound = false;
-    }
-
     void UpdateAI(const uint32 diff)
     {
         //Return since we have no target
@@ -141,11 +131,11 @@ struct boss_temporusAI : public ScriptedAI
         //Mortal Wound
         if (MortalWound_Timer < diff)
         {
-            //canApplyWound = true;
-
             if (m_creature->HasAura(SPELL_HASTE, 0))
+                me->CastSpell(target, SPELL_MORTAL_WOUND, true);
                 MortalWound_Timer = urand(2000, 3000);
             else
+                me->CastSpell(target, SPELL_MORTAL_WOUND, true);
                 MortalWound_Timer = urand(6000, 9000);
         }
         else

--- a/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
+++ b/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
@@ -47,7 +47,7 @@ struct boss_temporusAI : public ScriptedAI
 
     ScriptedInstance *pInstance;
     bool HeroicMode;
-    bool canApplyWound;
+    //bool canApplyWound;
 
     uint32 MortalWound_Timer;
     uint32 WingBuffet_Timer;
@@ -56,11 +56,11 @@ struct boss_temporusAI : public ScriptedAI
 
     void Reset()
     {
-        MortalWound_Timer = 5000;
-        canApplyWound = false;
+        MortalWound_Timer = 8000;
+        //canApplyWound = false;
         WingBuffet_Timer = 10000;
-        Haste_Timer = 20000;
-        SpellReflection_Timer = 40000;
+        Haste_Timer = urand(15000, 23000);
+        SpellReflection_Timer = 30000;
         m_creature->setActive(true);
 
         SayIntro();
@@ -108,10 +108,10 @@ struct boss_temporusAI : public ScriptedAI
 
     void DamageMade(Unit* target, uint32 & damage, bool direct_damage)
     {
-        if (canApplyWound)
+        //if (canApplyWound)
             me->CastSpell(target, SPELL_MORTAL_WOUND, true);
 
-        canApplyWound = false;
+        //canApplyWound = false;
     }
 
     void UpdateAI(const uint32 diff)
@@ -141,7 +141,7 @@ struct boss_temporusAI : public ScriptedAI
         //Mortal Wound
         if (MortalWound_Timer < diff)
         {
-            canApplyWound = true;
+            //canApplyWound = true;
 
             if (m_creature->HasAura(SPELL_HASTE, 0))
                 MortalWound_Timer = urand(2000, 3000);
@@ -155,7 +155,7 @@ struct boss_temporusAI : public ScriptedAI
         if (HeroicMode && SpellReflection_Timer < diff)
         {
             AddSpellToCast(m_creature, SPELL_REFLECT);
-            SpellReflection_Timer = urand(40000, 50000);
+            SpellReflection_Timer = urand(25000, 35000);
         }
         else
             SpellReflection_Timer -= diff;

--- a/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
+++ b/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
@@ -133,11 +133,9 @@ struct boss_temporusAI : public ScriptedAI
         {
             AddSpellToCast(m_creature, SPELL_MORTAL_WOUND);
                 if (m_creature->HasAura(SPELL_HASTE, 0))
-                {
                     MortalWound_Timer = urand(2000, 3000);
-                    else
+                else
                     MortalWound_Timer = urand(6000, 9000);
-                }
         }
         else
             MortalWound_Timer -= diff;

--- a/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
+++ b/src/scripts/scripts/zone/caverns_of_time/dark_portal/boss_temporus.cpp
@@ -131,12 +131,13 @@ struct boss_temporusAI : public ScriptedAI
         //Mortal Wound
         if (MortalWound_Timer < diff)
         {
-            if (m_creature->HasAura(SPELL_HASTE, 0))
-                me->CastSpell(target, SPELL_MORTAL_WOUND, true);
-                MortalWound_Timer = urand(2000, 3000);
-            else
-                me->CastSpell(target, SPELL_MORTAL_WOUND, true);
-                MortalWound_Timer = urand(6000, 9000);
+            AddSpellToCast(m_creature, SPELL_MORTAL_WOUND);
+                if (m_creature->HasAura(SPELL_HASTE, 0))
+                {
+                    MortalWound_Timer = urand(2000, 3000);
+                    else
+                    MortalWound_Timer = urand(6000, 9000);
+                }
         }
         else
             MortalWound_Timer -= diff;


### PR DESCRIPTION
https://github.com/cmangos/mangos-tbc/blob/master/src/scriptdev2/scripts/kalimdor/caverns_of_time/dark_portal/boss_temporus.cpp

Mortal Wound is a stacking debuff, should not check for active Mortal Wound and skip timer.

Resolves https://bitbucket.org/looking4group_b2tbc/looking4group/issues/1491/black-morras-nonhc-issues (2)

Could not find something producing a repeated unintentional text output. 

Needs to be rechecked.