### PR TITLE
Magtheridon Mind Exhaustion Duration

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3581,8 +3581,8 @@ void SpellMgr::LoadSpellCustomAttr()
             case 32686: //earthsquake doomwalker 
                 spellInfo->AttributesCu |= SPELL_ATTR_CU_IGNORE_ARMOR; 
                 break;
-            case 44032: // Mind Exhaust  Magtheridon
-                spellInfo->DurationIndex = 23;
+            case 44032: // Mind Exhaustion Magtheridon
+                spellInfo->DurationIndex = 25;
             break;
             case 24869: //Halooween food
                 spellInfo->Effect[2] = 6;


### PR DESCRIPTION
From another SpellDuration.dbc // Needs to be rechecked, discussed:

Set Duration of Magtheridon Mind Exhaustion Debuff to 180secs from  90secs.

https://bitbucket.org/looking4group_b2tbc/looking4group/issues/1553/magtheridons-lair

"After they stop channeling, players will be affected by Mind Exhaustion which makes them unable to use a Manticron Cube for 3 minutes." 

http://www.ownedcore.com/forums/world-of-warcraft/world-of-warcraft-guides/14600-magtheridon-strategy-guide.html

Shows clearly that it is 3minutes https://www.youtube.com/watch?v=v0PNXZYuAnU

Also https://www.youtube.com/watch?v=QpgdAHJANcA hard to see the # because of really low quality and you cant check the video timer because they jump in time twice, while he has it however it is clear that from 3:29 to 5:10 when it fades it is more than 90 seconds. First time jump is about 10% of boss health from over 90% to ~80%.

As suggested i recommend that we reduce his melee damage if this is changed.