### PR TITLE
/petfollow works when pet is cced

### DIFF
--- a/src/game/PetAI.cpp
+++ b/src/game/PetAI.cpp
@@ -108,7 +108,7 @@ void PetAI::_stopAttack()
 
 void PetAI::UpdateMotionMaster()
 {
-    if (m_owner && me->GetCharmInfo() && me->GetCharmInfo()->HasCommandState(COMMAND_FOLLOW) && !m_creature->hasUnitState(UNIT_STAT_CASTING))
+    if (m_owner && me->GetCharmInfo() && me->GetCharmInfo()->HasCommandState(COMMAND_FOLLOW) && (!m_creature->hasUnitState(UNIT_STAT_CASTING) || !m_unit->hasUnitState(UNIT_STAT_CAN_NOT_REACT) || !m_unit->hasUnitState(UNIT_STAT_NOT_MOVE)))
         me->GetMotionMaster()->MoveFollow(m_owner,PET_FOLLOW_DIST,PET_FOLLOW_ANGLE);
     else
         me->GetMotionMaster()->MoveIdle();

--- a/src/game/PetAI.cpp
+++ b/src/game/PetAI.cpp
@@ -108,7 +108,7 @@ void PetAI::_stopAttack()
 
 void PetAI::UpdateMotionMaster()
 {
-    if (m_owner && me->GetCharmInfo() && me->GetCharmInfo()->HasCommandState(COMMAND_FOLLOW) && (!m_creature->hasUnitState(UNIT_STAT_CASTING) || !m_unit->hasUnitState(UNIT_STAT_CAN_NOT_REACT) || !m_unit->hasUnitState(UNIT_STAT_NOT_MOVE)))
+    if (m_owner && me->GetCharmInfo() && me->GetCharmInfo()->HasCommandState(COMMAND_FOLLOW) && (!m_creature->hasUnitState(UNIT_STAT_CASTING) && !m_unit->hasUnitState(UNIT_STAT_CAN_NOT_REACT) && !m_unit->hasUnitState(UNIT_STAT_NOT_MOVE)))
         me->GetMotionMaster()->MoveFollow(m_owner,PET_FOLLOW_DIST,PET_FOLLOW_ANGLE);
     else
         me->GetMotionMaster()->MoveIdle();


### PR DESCRIPTION
As the Change in the CharmInfo.cpp didnt work, or partly didnt work and there are already Checks inserted to the PetAI to make this scenario work out this may be able to fix the issue that pets can be called back through walls when cced behind walls.

It may not fix the fact that they glitch through walls as this might be connected to the Follow Function ignoring mmaps. 

Needs to be tested and reviewed. Dont know whether the brackets are needed.

https://bitbucket.org/looking4group_b2tbc/looking4group/issues/312/petfollow-works-when-pet-is-cced

https://github.com/Looking4Group/L4G_Core/blob/master/src/game/CharmInfo.cpp#L305

https://bitbucket.org/looking4group_b2tbc/looking4group/commits/38519bd12f1e

https://bitbucket.org/looking4group_b2tbc/looking4group/commits/0780b830af86
