### PR TITLE
Update boss_netherspite.cpp

### DIFF
--- a/src/scripts/scripts/zone/karazhan/boss_netherspite.cpp
+++ b/src/scripts/scripts/zone/karazhan/boss_netherspite.cpp
@@ -223,7 +223,9 @@ struct boss_netherspiteAI : public ScriptedAI
         PortalTimer = 10000;
         EmpowermentTimer = 10000;
         DoScriptText(EMOTE_PHASE_PORTAL,m_creature);
-        AttackStart(m_creature->getVictim());
+        DoResetThreat();
+        m_creature->getThreatManager().setCurrentVictim((HostilReference*)target);
+        m_creature->AI()->AttackStart(target);
     }
 
     void SwitchToBanishPhase()
@@ -350,7 +352,7 @@ struct boss_netherspiteAI : public ScriptedAI
                 if(Unit* target = SelectUnit(SELECT_TARGET_RANDOM,0,GetSpellMaxRange(SPELL_NETHERBREATH),true))
                     AddSpellToCast(target,SPELL_NETHERBREATH);
 
-                NetherbreathTimer = 5000+rand()%2000;
+                NetherbreathTimer = urand(4000, 5000);
             }
             else
                 NetherbreathTimer -= diff;


### PR DESCRIPTION
https://github.com/cmangos/mangos-tbc/blob/master/src/scriptdev2/scripts/eastern_kingdoms/karazhan/boss_netherspite.cpp

https://github.com/cmangos/mangos-tbc/blob/master/src/scriptdev2/scripts/eastern_kingdoms/karazhan/boss_netherspite.cpp#L215 - Threat Reset

http://wowwiki.wikia.com/wiki/Netherspite

After 30 seconds, Netherspite starts a fresh Portal phase and clears his aggro table.

Aggro Reset taken from: https://github.com/Looking4Group/L4G_Core/blob/1d3b91f10f4b42323454f641490a78fd3854d430/src/scripts/scripts/custom/boss_easter_event.cpp

Needs to be tested.

I dont know if its possible to just DoResetThreat(); AttackStart(m_creature->getVictim()); without crashing server as he doesnt have a victim, dont know how DoResetThreat works. (Complete Drop of Threat resulting in Evade? -> Therefore need to make him select new target and attack this?)
