### PR TITLE
Update boss_broggok.cpp

### DIFF
--- a/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_broggok.cpp
+++ b/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_broggok.cpp
@@ -75,7 +75,7 @@ struct boss_broggokAI : public ScriptedAI
     void Reset()
     {
         AcidSpray_Timer = 10000;
-        PoisonSpawn_Timer = 5000;
+        PoisonSpawn_Timer = urand(8000, 12000);
         PoisonBolt_Timer = 7000;
         checkTimer = 3000;
 


### PR DESCRIPTION
https://github.com/Looking4Group/L4G_Core/pull/87/files

doesnt work out on hellfire, as he instantly engages combat here making him cast the first poison cloud when he is still far away from the group.

Normally the Boss should move in by a waypoint script, not by engaging combat with the group.