### PR TITLE
Gruul HurtfulStrike Timer and HurtfulStrike Facing

### DIFF
--- a/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
+++ b/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
@@ -76,6 +76,7 @@ struct boss_gruulAI : public ScriptedAI
     {
         pInstance = c->GetInstanceData();
         c->GetPosition(wLoc);
+        me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
     }
 
     ScriptedInstance *pInstance;

--- a/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
+++ b/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
@@ -99,7 +99,7 @@ struct boss_gruulAI : public ScriptedAI
         CaveIn_Timer = 27000;
         GroundSlamTimer = 35000;
         ShatterTimer = 0;
-        HurtfulStrike_Timer = 8000;
+        HurtfulStrike_Timer = 5000;
         Reverberation_Timer = 105000;
         Check_Timer = 3000;
         CaveInReduce = 2000;
@@ -181,7 +181,7 @@ struct boss_gruulAI : public ScriptedAI
                     me->SetSelection(victim->GetGUID());
                 }
 
-                HurtfulStrike_Timer = 8000;
+                HurtfulStrike_Timer = 5000;
                 ShatterTimer = 0;
 
                 //The dummy shatter spell is cast
@@ -201,8 +201,10 @@ struct boss_gruulAI : public ScriptedAI
                 if (!target)
                     target = me->getVictim();
 
+                me->SetSelection(target->GetGUID());
+                me->SetInFront(target);
                 AddSpellToCast(target, SPELL_HURTFUL_STRIKE);
-                HurtfulStrike_Timer = 8000;
+                HurtfulStrike_Timer = 5000;
             }
             else
                 HurtfulStrike_Timer -= diff;

--- a/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
+++ b/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
@@ -76,7 +76,6 @@ struct boss_gruulAI : public ScriptedAI
     {
         pInstance = c->GetInstanceData();
         c->GetPosition(wLoc);
-        me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
         me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
     }
 

--- a/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
+++ b/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
@@ -77,6 +77,7 @@ struct boss_gruulAI : public ScriptedAI
         pInstance = c->GetInstanceData();
         c->GetPosition(wLoc);
         me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
+        me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
     }
 
     ScriptedInstance *pInstance;

--- a/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
+++ b/src/scripts/scripts/zone/gruuls_lair/boss_gruul.cpp
@@ -99,7 +99,7 @@ struct boss_gruulAI : public ScriptedAI
         CaveIn_Timer = 27000;
         GroundSlamTimer = 35000;
         ShatterTimer = 0;
-        HurtfulStrike_Timer = 5000;
+        HurtfulStrike_Timer = 6000;
         Reverberation_Timer = 105000;
         Check_Timer = 3000;
         CaveInReduce = 2000;
@@ -181,7 +181,7 @@ struct boss_gruulAI : public ScriptedAI
                     me->SetSelection(victim->GetGUID());
                 }
 
-                HurtfulStrike_Timer = 5000;
+                HurtfulStrike_Timer = 6000;
                 ShatterTimer = 0;
 
                 //The dummy shatter spell is cast
@@ -204,7 +204,7 @@ struct boss_gruulAI : public ScriptedAI
                 me->SetSelection(target->GetGUID());
                 me->SetInFront(target);
                 AddSpellToCast(target, SPELL_HURTFUL_STRIKE);
-                HurtfulStrike_Timer = 5000;
+                HurtfulStrike_Timer = 6000;
             }
             else
                 HurtfulStrike_Timer -= diff;


### PR DESCRIPTION
https://youtu.be/jAslYF5SleY?t=50s (maybe right at start but that might be pulling threat) -> 59 1:04 1:09 1:14 1:19 shatter 1:39 1:43 1:48 X 1:58 2:03 2:08 also good evidence that the timer is obviously wrong, might want to decrease damage a little bit.

Video might be speed up a little bit, then i am wrong with the Timer. Seems a little bit speed up as you can see with the player movement. Therefore ->

THIS: https://www.youtube.com/watch?v=06rYTdIwX8I Pull 0:25 0:30 0.:37 0:43 0:49 Shatter 1:12 1:18 1:24 1:30 1:36 - 1:48 Shatter 2:11 2:17 Aggro 2:29 2:35 2:41 2:47 2:54

Resolves https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2236/some-problems-on-gruul (3)

And adding melee haste immunity (no db flag for this) https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2681/doomguard-cripple

And omg you can make him and all bosses kiteable by using http://db.looking4group.eu/?spell=31896 ...

