### PR TITLE
Add JoJ Immunity to Bosses as there is no Flag for this and Add Cripple Immunity to CREATURE_FLAG_EXTRA_HASTE_IMMUNE

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -466,10 +466,9 @@ bool Creature::UpdateEntry(uint32 Entry, uint32 team, const CreatureData *data)
     //  NO BOSSES should be able to be silenced/set to speed 1.0/have their attackspeed altered.
     if (isWorldBoss())
     {
-    ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_SILENCE, true);
-    ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
-    ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
-    ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_RANGED, true); 
+        ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_SILENCE, true);
+        ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
+        ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
     }
     
     return true;

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -781,6 +781,7 @@ bool Creature::Create(uint32 guidlow, Map *map, uint32 Entry, uint32 team, float
         LoadCreaturesAddon();
         if (GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_HASTE_IMMUNE)
             ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_SPELLS, true);
+            ApplySpellImmune(0, IMMUNITY_ID, 20812, true);
     }
     return bResult;
 }

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -779,8 +779,10 @@ bool Creature::Create(uint32 guidlow, Map *map, uint32 Entry, uint32 team, float
         }
         LoadCreaturesAddon();
         if (GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_HASTE_IMMUNE)
+        {    
             ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_SPELLS, true);
             ApplySpellImmune(0, IMMUNITY_ID, 20812, true);
+        }    
     }
     return bResult;
 }

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -463,10 +463,9 @@ bool Creature::UpdateEntry(uint32 Entry, uint32 team, const CreatureData *data)
         ApplySpellImmune(0, IMMUNITY_EFFECT,SPELL_EFFECT_ATTACK_ME, true);
     }
     
-    //  NO BOSSES should be able to be silenced/set to speed 1.0/have their attackspeed altered.
+    //  NO BOSSES should be subject to Judgement of Justice which sets their Movementspeed to 1.0 making them kiteable
     if (isWorldBoss())
     {
-        ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_SILENCE, true);
         ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
     }
     

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -468,7 +468,6 @@ bool Creature::UpdateEntry(uint32 Entry, uint32 team, const CreatureData *data)
     {
         ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_SILENCE, true);
         ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
-        ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
     }
     
     return true;

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -462,7 +462,14 @@ bool Creature::UpdateEntry(uint32 Entry, uint32 team, const CreatureData *data)
         ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_TAUNT, true);
         ApplySpellImmune(0, IMMUNITY_EFFECT,SPELL_EFFECT_ATTACK_ME, true);
     }
-
+    
+    //  NO BOSSES should be able to be silenced/set to speed 1.0.
+    if (isWorldBoss())
+    {
+    ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_SILENCE, true);
+    ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
+    }
+    
     return true;
 }
 

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -463,11 +463,13 @@ bool Creature::UpdateEntry(uint32 Entry, uint32 team, const CreatureData *data)
         ApplySpellImmune(0, IMMUNITY_EFFECT,SPELL_EFFECT_ATTACK_ME, true);
     }
     
-    //  NO BOSSES should be able to be silenced/set to speed 1.0.
+    //  NO BOSSES should be able to be silenced/set to speed 1.0/have their attackspeed altered.
     if (isWorldBoss())
     {
     ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_SILENCE, true);
     ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED, true);
+    ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true);
+    ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_RANGED, true); 
     }
     
     return true;


### PR DESCRIPTION
Disable Kiting and Silencing(unlikely as this can be set as db value) of Bosses.

Preventing Abuse Tactics, pretty sure there is no Boss where this should be possible. 

ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_MELEE, true); 
ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_HASTE_RANGED, true); -> not needed imao

should be added to https://github.com/Looking4Group/L4G_Core/blob/b8e6db5c6679e44ef30e9d0b27342e99a3764669/src/game/Creature.cpp#L775 as normally its either a Caster Npc or a Melee Npc and everything could be done by setting one flag.

https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2681/doomguard-cripple

Numeration may be wrong? What happens if Boss has set ApplySpelllImmune(0) elsewhere? -> Use ~6,7,8,9 then 0-5 can be used in Bossscript. See: https://github.com/Looking4Group/L4G_Core/pull/160/files

thx@ https://bitbucket.org/Caboon/playcore-official/commits/53baa316386b0c117ec2b0acbc182514c94b3692 