### PR TITLE
LurkerWhirl

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3377,9 +3377,9 @@ void SpellMgr::LoadSpellCustomAttr()
             case 66:    // Invisibility (fading) - break on casting spell
                 spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CAST;
                 break;
-            case 37363: // set 5y radius instead of 25y
-                spellInfo->EffectRadiusIndex[0] = 8;
-                spellInfo->EffectRadiusIndex[1] = 8;
+            case 37363: // set 8y radius instead of 25y
+                spellInfo->EffectRadiusIndex[0] = 14;
+                spellInfo->EffectRadiusIndex[1] = 14;
                 spellInfo->EffectMiscValue[1] = 50;
                 break;
             case 42835: // set visual only


### PR DESCRIPTION
Set Radius to 8y as melees should not be able to outrange the http://www.wowhead.com/spell=37660/whirl of Lurker, while still being able to hit him. EFFECT_RADIUS_8_YARDS = 14

It was set to 5y as spellcastrange is calculated from the outside of the hitbox on this server, but 5y is too small.

Maybe even EFFECT_RADIUS_6_YARDS = 29 / EFFECT_RADIUS_7_YARDS = 37 is enough but i guess 8y is ok.