### PR TITLE
Advisors_HP

### DIFF
--- a/src/scripts/scripts/zone/tempest_keep/the_eye/boss_kaelthas.cpp
+++ b/src/scripts/scripts/zone/tempest_keep/the_eye/boss_kaelthas.cpp
@@ -192,10 +192,10 @@ float KaelthasWeapons[7][5] =
 #define SPELL_STAFF_WBOLT       36990 // frostbolt
 
 // Advisors hp
-#define HP_THALADRED    756000
-#define HP_SANGUINAR    752000
-#define HP_CAPERNIAN    562000
-#define HP_TELONICUS    754000
+#define HP_THALADRED    378000
+#define HP_SANGUINAR    376000
+#define HP_CAPERNIAN    281000
+#define HP_TELONICUS    377000
 
 //Base AI for Advisors
 struct advisorbase_ai : public ScriptedAI

--- a/src/scripts/scripts/zone/tempest_keep/the_eye/boss_kaelthas.cpp
+++ b/src/scripts/scripts/zone/tempest_keep/the_eye/boss_kaelthas.cpp
@@ -192,10 +192,10 @@ float KaelthasWeapons[7][5] =
 #define SPELL_STAFF_WBOLT       36990 // frostbolt
 
 // Advisors hp
-#define HP_THALADRED    279999
-#define HP_SANGUINAR    289999
-#define HP_CAPERNIAN    199999
-#define HP_TELONICUS    274999
+#define HP_THALADRED    756000
+#define HP_SANGUINAR    752000
+#define HP_CAPERNIAN    562000
+#define HP_TELONICUS    754000
 
 //Base AI for Advisors
 struct advisorbase_ai : public ScriptedAI


### PR DESCRIPTION
http://looking4group.eu/quelthalas/forum/index.php?page=Thread&postID=3278#post3278

https://bitbucket.org/looking4group_b2tbc/looking4group/issues/2233/tempest-keep-the-eye

http://looking4group.eu/hellfire/showthread.php?tid=2237

```
-- Documented 10% Nerf for Advisors and Weapons
--
-- Phase 1 HP Values for Advisors as they are doubled in Phase 3.
--
-- Thaladred the Darkener <Advisor to Kael'thas> 20064
UPDATE `creature_template` SET `minhealth`='378000',`maxhealth`='378000' WHERE `entry` = 20064; -- 280000 -- 378000
--
-- Lord Sanguinar <The Blood Hammer> 20060
UPDATE `creature_template` SET `minhealth`='376000',`maxhealth`='376000' WHERE `entry` = 20060; -- 290000 -- 376000
--
-- Grand Astromancer Capernian <Advisor to Kael'thas> 20062
UPDATE `creature_template` SET `minhealth`='281000',`maxhealth`='281000' WHERE `entry` = 20062; -- 200000 -- 281000
--
-- Master Engineer Telonicus <Advisor to Kael'thas> 20063
UPDATE `creature_template` SET `minhealth`='377000',`maxhealth`='377000' WHERE `entry` = 20063; -- 275000 -- 377000

```