### PR TITLE
SSC Refactor

### DIFF
--- a/sql/updates/world/055_SSC_Consoles.sql
+++ b/sql/updates/world/055_SSC_Consoles.sql
@@ -1,0 +1,12 @@
+-- 5x Serpentshrine Console
+UPDATE `gameobject_template`
+SET `type`=1, `flags`=34, `data1`=86, `ScriptName`='GOUse_go_vashj_console_access_panel'
+WHERE `entry` IN(185114, 185115, 185116, 185117, 185118);
+-- Lady Vashj Bridge Console
+UPDATE `gameobject_template`
+SET `type`=0, `flags`=34, `data1`=86, `ScriptName`='GOUse_go_vashj_console_access_panel'
+WHERE `entry` = 184568;
+-- Lady Vashj Bridge
+UPDATE `gameobject`
+SET `animprogress`=100
+WHERE `guid` IN(80001,80002,80003,80004);

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_fathomlord_karathress.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_fathomlord_karathress.cpp
@@ -158,7 +158,7 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
             RAdvisors[2] = pInstance->GetData64(DATA_CARIBDIS);
 
             // Don't respawn adds if encounter is done
-            if(pInstance->GetData(DATA_KARATHRESSEVENT) == DONE)
+            if(pInstance->GetData(DATA_KARATHRESS_EVENT) == DONE)
             {
                 m_creature->SummonCreature(SEER_OLUM, OLUM_X, OLUM_Y, OLUM_Z, OLUM_O, TEMPSUMMON_MANUAL_DESPAWN, 0);
                 return;
@@ -181,7 +181,7 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
                     }
                 }
             }
-            pInstance->SetData(DATA_KARATHRESSEVENT, NOT_STARTED);
+            pInstance->SetData(DATA_KARATHRESS_EVENT, NOT_STARTED);
         }
     }
 
@@ -217,8 +217,8 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
         DoScriptText(SAY_AGGRO, m_creature);
         DoZoneInCombat();
 
-        pInstance->SetData64(DATA_KARATHRESSEVENT_STARTER, who->GetGUID());
-        pInstance->SetData(DATA_KARATHRESSEVENT, IN_PROGRESS);
+        pInstance->SetData64(DATA_KARATHRESS_EVENT_STARTER, who->GetGUID());
+        pInstance->SetData(DATA_KARATHRESS_EVENT, IN_PROGRESS);
     }
 
     void KilledUnit(Unit *victim)
@@ -231,7 +231,7 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
         DoScriptText(SAY_DEATH, m_creature);
 
         if(pInstance)
-            pInstance->SetData(DATA_KARATHRESSEVENT, DONE);
+            pInstance->SetData(DATA_KARATHRESS_EVENT, DONE);
 
         //support for quest 10944
         m_creature->SummonCreature(SEER_OLUM, OLUM_X, OLUM_Y, OLUM_Z, OLUM_O, TEMPSUMMON_TIMED_DESPAWN, 3600000);
@@ -245,9 +245,9 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
     void UpdateAI(const uint32 diff)
     {
         //Only if not incombat check if the event is started
-        if (!m_creature->isInCombat() && pInstance && pInstance->GetData(DATA_KARATHRESSEVENT))
+        if (!m_creature->isInCombat() && pInstance && pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
-            Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESSEVENT_STARTER));
+            Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESS_EVENT_STARTER));
 
             if (target)
             {
@@ -261,7 +261,7 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
             return;
 
         //someone evaded!
-        if (pInstance && !pInstance->GetData(DATA_KARATHRESSEVENT))
+        if (pInstance && !pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
             EnterEvadeMode();
             return;
@@ -429,15 +429,15 @@ struct boss_fathomguard_sharkkisAI : public ScriptedAI
     void EnterCombat(Unit *who)
     {
         if(pInstance)
-            pInstance->SetData64(DATA_KARATHRESSEVENT_STARTER, who->GetGUID());
+            pInstance->SetData64(DATA_KARATHRESS_EVENT_STARTER, who->GetGUID());
     }
 
     void UpdateAI(const uint32 diff)
     {
         //Only if not incombat check if the event is started
-        if (!m_creature->isInCombat() && pInstance && pInstance->GetData(DATA_KARATHRESSEVENT))
+        if (!m_creature->isInCombat() && pInstance && pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
-            if(Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESSEVENT_STARTER)))
+            if(Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESS_EVENT_STARTER)))
                 AttackStart(target);
         }
 
@@ -446,7 +446,7 @@ struct boss_fathomguard_sharkkisAI : public ScriptedAI
             return;
 
         //someone evaded!
-        if (pInstance && !pInstance->GetData(DATA_KARATHRESSEVENT))
+        if (pInstance && !pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
             EnterEvadeMode();
             return;
@@ -549,7 +549,7 @@ struct boss_fathomguard_tidalvessAI : public ScriptedAI
     void EnterCombat(Unit *who)
     {
         if (pInstance)
-            pInstance->SetData64(DATA_KARATHRESSEVENT_STARTER, who->GetGUID());
+            pInstance->SetData64(DATA_KARATHRESS_EVENT_STARTER, who->GetGUID());
 
         DoCast(m_creature, SPELL_WINDFURY_WEAPON);
     }
@@ -557,9 +557,9 @@ struct boss_fathomguard_tidalvessAI : public ScriptedAI
     void UpdateAI(const uint32 diff)
     {
         //Only if not incombat check if the event is started
-        if (!m_creature->isInCombat() && pInstance && pInstance->GetData(DATA_KARATHRESSEVENT))
+        if (!m_creature->isInCombat() && pInstance && pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
-            if(Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESSEVENT_STARTER)))
+            if(Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESS_EVENT_STARTER)))
                 AttackStart(target);
         }
 
@@ -568,7 +568,7 @@ struct boss_fathomguard_tidalvessAI : public ScriptedAI
             return;
 
         //someone evaded!
-        if(pInstance && !pInstance->GetData(DATA_KARATHRESSEVENT))
+        if(pInstance && !pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
             EnterEvadeMode();
             return;
@@ -674,15 +674,15 @@ struct boss_fathomguard_caribdisAI : public ScriptedAI
     void EnterCombat(Unit *who)
     {
         if(pInstance)
-            pInstance->SetData64(DATA_KARATHRESSEVENT_STARTER, who->GetGUID());
+            pInstance->SetData64(DATA_KARATHRESS_EVENT_STARTER, who->GetGUID());
     }
 
     void UpdateAI(const uint32 diff)
     {
         //Only if not incombat check if the event is started
-        if(pInstance && !m_creature->isInCombat() && pInstance->GetData(DATA_KARATHRESSEVENT))
+        if(pInstance && !m_creature->isInCombat() && pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
-            if(Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESSEVENT_STARTER)))
+            if(Unit* target = Unit::GetUnit((*m_creature), pInstance->GetData64(DATA_KARATHRESS_EVENT_STARTER)))
                 AttackStart(target);
         }
 
@@ -691,7 +691,7 @@ struct boss_fathomguard_caribdisAI : public ScriptedAI
             return;
 
         //someone evaded!
-        if(pInstance && !pInstance->GetData(DATA_KARATHRESSEVENT))
+        if(pInstance && !pInstance->GetData(DATA_KARATHRESS_EVENT))
         {
             EnterEvadeMode();
             return;

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_hydross_the_unstable.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_hydross_the_unstable.cpp
@@ -120,8 +120,8 @@ struct boss_hydross_the_unstableAI : public ScriptedAI
 
         m_creature->SetUInt32Value(UNIT_FIELD_DISPLAYID, MODEL_CLEAN);
 
-        if (pInstance && pInstance->GetData(DATA_HYDROSSTHEUNSTABLEEVENT) != DONE)
-            pInstance->SetData(DATA_HYDROSSTHEUNSTABLEEVENT, NOT_STARTED);
+        if (pInstance && ((pInstance->GetData(DATA_HYDROSS_EVENT) != DONE) || (pInstance->GetData(DATA_HYDROSS_EVENT) != SPECIAL)))
+            pInstance->SetData(DATA_HYDROSS_EVENT, NOT_STARTED);
 
         beam = false;
         Summons.DespawnAll();
@@ -163,7 +163,7 @@ struct boss_hydross_the_unstableAI : public ScriptedAI
         DoScriptText(SAY_AGGRO, m_creature);
 
         if (pInstance)
-            pInstance->SetData(DATA_HYDROSSTHEUNSTABLEEVENT, IN_PROGRESS);
+            pInstance->SetData(DATA_HYDROSS_EVENT, IN_PROGRESS);
     }
 
     void KilledUnit(Unit *victim)
@@ -203,7 +203,7 @@ struct boss_hydross_the_unstableAI : public ScriptedAI
             DoScriptText(SAY_CLEAN_DEATH, m_creature);
 
         if (pInstance)
-            pInstance->SetData(DATA_HYDROSSTHEUNSTABLEEVENT, DONE);
+            pInstance->SetData(DATA_HYDROSS_EVENT, DONE);
         Summons.DespawnAll();
     }
 

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
@@ -208,7 +208,7 @@ struct boss_lady_vashjAI : public ScriptedAI
             ShieldGeneratorChannel[i] = 0;
         }
 
-        instance->SetData(DATA_LADYVASHJEVENT, NOT_STARTED);
+        instance->SetData(DATA_VASHJ_EVENT, NOT_STARTED);
 
         me->SetCorpseDelay(1000*60*60);
     }
@@ -285,7 +285,7 @@ struct boss_lady_vashjAI : public ScriptedAI
         Paralyze(false);
         DoScriptText(SAY_DEATH, me);
 
-        instance->SetData(DATA_LADYVASHJEVENT, DONE);
+        instance->SetData(DATA_VASHJ_EVENT, DONE);
     }
 
     void StartEvent()
@@ -295,7 +295,7 @@ struct boss_lady_vashjAI : public ScriptedAI
         InCombat = true;
         Phase = 1;
 
-        instance->SetData(DATA_LADYVASHJEVENT, IN_PROGRESS);
+        instance->SetData(DATA_VASHJ_EVENT, IN_PROGRESS);
     }
 
     void EnterCombat(Unit *who)
@@ -656,7 +656,7 @@ struct boss_lady_vashjAI : public ScriptedAI
             if(Check_Timer < diff)
             {
                 //Start Phase 3
-                if(instance && instance->GetData(DATA_CANSTARTPHASE3))
+                if(instance && instance->GetData(DATA_CAN_START_PHASE_3))
                 {
                     //set life 50%
                     me->SetHealth(me->GetMaxHealth()/2);
@@ -725,7 +725,7 @@ struct mob_enchanted_elementalAI : public ScriptedAI
             }
         }
         if (instance)
-            Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_LADYVASHJ));
+            Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_VASHJ));
     }
 
     void EnterCombat(Unit *who) { return; }
@@ -812,7 +812,7 @@ struct mob_tainted_elementalAI : public Scripted_NoMovementAI
     {
         if(instance)
         {
-            Creature *Vashj = Unit::GetCreature((*me), instance->GetData64(DATA_LADYVASHJ));
+            Creature *Vashj = Unit::GetCreature((*me), instance->GetData64(DATA_VASHJ));
 
             if(Vashj)
                 ((boss_lady_vashjAI*)Vashj->AI())->EventTaintedElementalDeath();
@@ -912,7 +912,7 @@ struct mob_toxic_sporebatAI : public ScriptedAI
         //toxic spores
         if(bolt_timer < diff)
         {
-            Unit *Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_LADYVASHJ));
+            Unit *Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_VASHJ));
             if (Vashj)
             {
 
@@ -935,7 +935,7 @@ struct mob_toxic_sporebatAI : public ScriptedAI
             if(instance)
             {
                 //check if vashj is death
-                Unit *Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_LADYVASHJ));
+                Unit *Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_VASHJ));
                 if(!Vashj || (Vashj && !Vashj->isAlive()) || (Vashj && ((boss_lady_vashjAI*)((Creature*)Vashj)->AI())->Phase != 3))
                 {
                     //remove
@@ -1044,7 +1044,7 @@ struct mob_coilfang_eliteAI : public ScriptedAI
         {
             DoZoneInCombat();
 
-            if(instance && instance->GetData(DATA_LADYVASHJEVENT) != IN_PROGRESS)
+            if(instance && instance->GetData(DATA_VASHJ_EVENT) != IN_PROGRESS)
                 me->Kill(me,false);
 
               Check_Timer = 2000;
@@ -1162,7 +1162,7 @@ struct mob_coilfang_striderAI : public ScriptedAI
         {
             DoZoneInCombat();
 
-            if(instance && instance->GetData(DATA_LADYVASHJEVENT) != IN_PROGRESS)
+            if(instance && instance->GetData(DATA_VASHJ_EVENT) != IN_PROGRESS)
                 me->Kill(me,false);
 
               Check_Timer = 2000;
@@ -1214,7 +1214,7 @@ struct mob_shield_generator_channelAI : public ScriptedAI
         if(Check_Timer < diff)
         {
             Unit *Vashj = NULL;
-            Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_LADYVASHJ));
+            Vashj = Unit::GetUnit((*me), instance->GetData64(DATA_VASHJ));
 
             if(Vashj && Vashj->isAlive())
             {
@@ -1249,7 +1249,7 @@ bool ItemUse_item_tainted_core(Player *player, Item* _Item, SpellCastTargets con
         return true;
     }
 
-    Creature *Vashj = Unit::GetCreature((*player), instance->GetData64(DATA_LADYVASHJ));
+    Creature *Vashj = Unit::GetCreature((*player), instance->GetData64(DATA_VASHJ));
     if(Vashj && ((boss_lady_vashjAI*)Vashj->AI())->Phase == 2)
     {
         if(targets.getGOTarget() && targets.getGOTarget()->GetTypeId()==TYPEID_GAMEOBJECT)
@@ -1259,19 +1259,19 @@ bool ItemUse_item_tainted_core(Player *player, Item* _Item, SpellCastTargets con
             switch(targets.getGOTarget()->GetEntry())
             {
                 case 185052:
-                    identifier = DATA_SHIELDGENERATOR1;
+                    identifier = DATA_SHIELD_GENERATOR_ONE;
                     channel_identifier = 0;
                     break;
                 case 185053:
-                    identifier = DATA_SHIELDGENERATOR2;
+                    identifier = DATA_SHIELD_GENERATOR_TWO;
                     channel_identifier = 1;
                     break;
                 case 185051:
-                    identifier = DATA_SHIELDGENERATOR3;
+                    identifier = DATA_SHIELD_GENERATOR_THREE;
                     channel_identifier = 2;
                     break;
                 case 185054:
-                    identifier = DATA_SHIELDGENERATOR4;
+                    identifier = DATA_SHIELD_GENERATOR_FOUR;
                     channel_identifier = 3;
                     break;
                 default:

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_leotheras_the_blind.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_leotheras_the_blind.cpp
@@ -216,8 +216,8 @@ struct boss_leotheras_the_blindAI : public ScriptedAI
         m_creature->CastSpell(m_creature, SPELL_DUAL_WIELD, true);
         m_creature->SetCorpseDelay(1000*60*60);
 
-        if(pInstance && pInstance->GetData(DATA_LEOTHERASTHEBLINDEVENT) != DONE)
-            pInstance->SetData(DATA_LEOTHERASTHEBLINDEVENT, NOT_STARTED);
+        if(pInstance && pInstance->GetData(DATA_LEOTHERAS_EVENT) != DONE) // check for not special also
+            pInstance->SetData(DATA_LEOTHERAS_EVENT, NOT_STARTED);
 
         m_creature->SetReactState(REACT_AGGRESSIVE);
         m_creature->SetMeleeDamageSchool(SPELL_SCHOOL_NORMAL);
@@ -277,7 +277,7 @@ struct boss_leotheras_the_blindAI : public ScriptedAI
         DoZoneInCombat();
         DoScriptText(SAY_AGGRO, m_creature);
         if(pInstance)
-            pInstance->SetData(DATA_LEOTHERASTHEBLINDEVENT, IN_PROGRESS);
+            pInstance->SetData(DATA_LEOTHERAS_EVENT, IN_PROGRESS);
     }
 
     void CheckBanish()
@@ -389,7 +389,7 @@ struct boss_leotheras_the_blindAI : public ScriptedAI
                 pUnit->DealDamage(pUnit, pUnit->GetHealth(), DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, false);
         }
         if (pInstance)
-            pInstance->SetData(DATA_LEOTHERASTHEBLINDEVENT, DONE);
+            pInstance->SetData(DATA_LEOTHERAS_EVENT, DONE);
     }
 
     void EnterCombat(Unit *who)
@@ -721,7 +721,7 @@ struct mob_greyheart_spellbinderAI : public ScriptedAI
 
         if(pInstance)
         {
-            if (pInstance->GetData(DATA_LEOTHERASTHEBLINDEVENT) != NOT_STARTED)
+            if (pInstance->GetData(DATA_LEOTHERAS_EVENT) != NOT_STARTED)
             {
                 m_creature->Kill(m_creature,false);
                 return;
@@ -737,7 +737,9 @@ struct mob_greyheart_spellbinderAI : public ScriptedAI
     {
         m_creature->InterruptNonMeleeSpells(false);
         if(pInstance)
+        {
             pInstance->SetData64(DATA_LEOTHERAS_EVENT_STARTER, who->GetGUID());
+        }
     }
 
     void JustRespawned()

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lurker_below.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lurker_below.cpp
@@ -77,7 +77,7 @@ enum LurkerEvents
 
 struct boss_the_lurker_belowAI : public BossAI
 {
-    boss_the_lurker_belowAI(Creature *c) : BossAI(c, DATA_THELURKERBELOW) { 
+    boss_the_lurker_belowAI(Creature *c) : BossAI(c, DATA_LURKER) { 
         SpellEntry *TempSpell = (SpellEntry*)GetSpellStore()->LookupEntry(36151);
         if(TempSpell)
         {
@@ -108,8 +108,8 @@ struct boss_the_lurker_belowAI : public BossAI
         ClearCastQueue();
         events.Reset();
 
-        instance->SetData(DATA_THELURKERBELOWEVENT, NOT_STARTED);
-        instance->SetData(DATA_STRANGE_POOL, NOT_STARTED);
+        instance->SetData(DATA_LURKER_EVENT, NOT_STARTED);
+        instance->SetData(DATA_LURKER_FISHING_EVENT, NOT_STARTED);
 
         // Do not fall to the ground ;]
         me->AddUnitMovementFlag(MOVEFLAG_SWIMMING);
@@ -249,7 +249,7 @@ struct boss_the_lurker_belowAI : public BossAI
 
     void EnterCombat(Unit *who)
     {        
-        instance->SetData(DATA_THELURKERBELOWEVENT, IN_PROGRESS);
+        instance->SetData(DATA_LURKER_EVENT, IN_PROGRESS);
         me->SetReactState(REACT_AGGRESSIVE);        
         AttackStart(who);
     }
@@ -273,7 +273,7 @@ struct boss_the_lurker_belowAI : public BossAI
 
     void JustDied(Unit* Killer)
     {
-        instance->SetData(DATA_THELURKERBELOWEVENT, DONE);
+        instance->SetData(DATA_LURKER_EVENT, DONE);
         me->RemoveAurasDueToSpell(SPELL_SUBMERGE);
     }
 
@@ -318,7 +318,7 @@ struct boss_the_lurker_belowAI : public BossAI
 
     void UpdateAI(const uint32 diff)
     {
-        if (instance->GetData(DATA_STRANGE_POOL) != IN_PROGRESS)
+        if (instance->GetData(DATA_LURKER_FISHING_EVENT) != DONE)
             return;
 
         //boss is invisible, don't attack

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_morogrim_tidewalker.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_morogrim_tidewalker.cpp
@@ -108,7 +108,7 @@ struct boss_morogrim_tidewalkerAI : public ScriptedAI
         Phase2 = false;
         m_creature->CastSpell(m_creature, SPELL_THRASH_PASSIVE, true);
 
-        pInstance->SetData(DATA_MOROGRIMTIDEWALKEREVENT, NOT_STARTED);
+        pInstance->SetData(DATA_MOROGRIM_EVENT, NOT_STARTED);
     }
 
     void KilledUnit(Unit *victim)
@@ -119,13 +119,13 @@ struct boss_morogrim_tidewalkerAI : public ScriptedAI
     void JustDied(Unit *victim)
     {
         DoScriptText(SAY_DEATH, m_creature);
-        pInstance->SetData(DATA_MOROGRIMTIDEWALKEREVENT, DONE);
+        pInstance->SetData(DATA_MOROGRIM_EVENT, DONE);
     }
 
     void EnterCombat(Unit *who)
     {
         DoScriptText(SAY_AGGRO, m_creature);
-        pInstance->SetData(DATA_MOROGRIMTIDEWALKEREVENT, IN_PROGRESS);
+        pInstance->SetData(DATA_MOROGRIM_EVENT, IN_PROGRESS);
     }
 
     void UpdateAI(const uint32 diff)

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/def_serpent_shrine.h
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/def_serpent_shrine.h
@@ -5,12 +5,13 @@
 #ifndef DEF_SERPENT_SHRINE_H
 #define DEF_SERPENT_SHRINE_H
 
-enum LurkerEventState
-{
-    LURKER_NOT_STARTED = 0,
-    LURKER_FISHING     = 1,
-    LURKER_HOOKED      = 2
-};
+#define MAX_ENCOUNTER 6
+#define LURKER_FISHING_INTERNAL_COOLDOWN 7000
+#define MOB_GREYHEART_TECHNICIAN 21263
+#define SPELL_SCALDINGWATER 37284
+#define MOB_COILFANG_FRENZY 21508
+#define WATER_Z -19.9f
+
 enum WaterEventState
 {
     WATERSTATE_NONE     = 0,
@@ -18,31 +19,40 @@ enum WaterEventState
     WATERSTATE_SCALDING = 2
 };
 
-#define DATA_CANSTARTPHASE3 1
-#define DATA_CARIBDIS 2
-#define DATA_HYDROSSTHEUNSTABLEEVENT 3
-#define DATA_KARATHRESS 4
-#define DATA_KARATHRESSEVENT 5
-#define DATA_KARATHRESSEVENT_STARTER 6
-#define DATA_LADYVASHJ 7
-#define DATA_LADYVASHJEVENT 8
-#define DATA_LEOTHERASTHEBLINDEVENT 9
-#define DATA_MOROGRIMTIDEWALKEREVENT 10
-#define DATA_SHARKKIS 11
-#define DATA_SHIELDGENERATOR1 12
-#define DATA_SHIELDGENERATOR2 13
-#define DATA_SHIELDGENERATOR3 14
-#define DATA_SHIELDGENERATOR4 15
-#define DATA_THELURKERBELOW 16
-#define DATA_THELURKERBELOWEVENT 17
-#define DATA_TIDALVESS 18
-#define DATA_LEOTHERAS 19
-#define DATA_LEOTHERAS_EVENT_STARTER 20
-#define DATA_CONTROL_CONSOLE 21
-#define DATA_STRANGE_POOL 22
-#define DATA_WATER 23
-#define DATA_SHARKKIS_PET 24
+enum DataTypes
+{        
+    /* Encounters */
+    DATA_HYDROSS_EVENT              = 1,
+    DATA_LURKER_EVENT               = 2,
+    DATA_LEOTHERAS_EVENT            = 3,
+    DATA_KARATHRESS_EVENT           = 4,
+    DATA_MOROGRIM_EVENT             = 5,
+    DATA_VASHJ_EVENT                = 6,
 
-#define WATER_Z -19.9f
+    /* Creatures */
+    DATA_HYDROSS                    = 7,
+    DATA_LURKER                     = 8,
+    DATA_LEOTHERAS                  = 9,
+    DATA_KARATHRESS                 = 10,
+    DATA_MOROGRIM                   = 11,
+    DATA_VASHJ                      = 12,
+    DATA_SHARKKIS                   = 13,
+    DATA_TIDALVESS                  = 14,
+    DATA_CARIBDIS                   = 15,
+    DATA_SHARKKIS_PET               = 16,
+    DATA_LEOTHERAS_EVENT_STARTER    = 17,
+    DATA_KARATHRESS_EVENT_STARTER   = 18,
+    
+    /* Misc */
+    DATA_BRIDGE_CONSOLE             = 43,
+    DATA_LURKER_FISHING_EVENT       = 44,
+    DATA_SHIELD_GENERATOR_ONE       = 45,
+    DATA_SHIELD_GENERATOR_TWO       = 46,
+    DATA_SHIELD_GENERATOR_THREE     = 47,
+    DATA_SHIELD_GENERATOR_FOUR      = 48,
+    DATA_CAN_START_PHASE_3          = 49,
+    DATA_WATER                      = 50,
+};
+
 #endif
 

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
@@ -24,255 +24,246 @@ EndScriptData */
 #include "precompiled.h"
 #include "def_serpent_shrine.h"
 
-#define ENCOUNTERS 6
-
-#define SPELL_SCALDINGWATER 37284
-#define MOB_COILFANG_FRENZY 21508
-#define TRASHMOB_COILFANG_TECHNI 21263
-
-uint64 consoles[6] = {0,0,0,0,0,0};
-
-bool c1_used = false, c2_used = false, c3_used = false, c4_used = false, c5_used = false;
-
-uint64 ControlConsole = 0;
-
-
 /* Serpentshrine cavern encounters:
-0 - Hydross The Unstable event
-1 - Leotheras The Blind Event
-2 - The Lurker Below Event
-3 - Fathom-Lord Karathress Event
-4 - Morogrim Tidewalker Event
-5 - Lady Vashj Event
+0 - Hydross the Unstable
+1 - The Lurker Below
+2 - Leotheras the Blind
+3 - Fathom-Lord Karathress
+4 - Morogrim Tidewalker
+5 - Lady Vashj
 */
-/*
-bool GOUse_go_bridge_console(Player *player, GameObject* go)
-{
-ScriptedInstance* pInstance = (ScriptedInstance*)go->GetInstanceData();
 
-if(!pInstance )
-return false;
-
-if (c1_used && c2_used && c3_used && c4_used && c5_used){
-pInstance->SetData(DATA_CONTROL_CONSOLE, DONE);
-return true;
-}
-
-return false;
-}*/
+ObjectGuid ConsoleGuids[5]; 
+ObjectGuid BridgeConsoleGuid;
 
 bool GOUse_go_vashj_console_access_panel(Player *player, GameObject* go)
 {
-    ScriptedInstance* pInstance = (ScriptedInstance*)go->GetInstanceData();
+    ScriptedInstance* instance = (ScriptedInstance*) go->GetInstanceData();
 
-    if(!pInstance)
+    if (!instance)
+    {
         return false;
+    }
 
-    if (go->GetGUID() == consoles[1])
-        if (!c1_used && (pInstance->GetData(DATA_HYDROSSTHEUNSTABLEEVENT) == DONE)){
-            c1_used = true;
-            go->Say("c1_activated", LANG_UNIVERSAL,player->GetGUID());
-        }
+    ObjectGuid id;
+    id = go->GetGUID();
 
-        if (go->GetGUID() == consoles[2])
-            if (!c2_used && (pInstance->GetData(DATA_THELURKERBELOWEVENT) == DONE)){
-                c2_used = true;
-                go->Say("c2_activated", LANG_UNIVERSAL,player->GetGUID());
-            }
-
-            if (go->GetGUID() == consoles[3])
-                if (!c3_used && (pInstance->GetData(DATA_LEOTHERASTHEBLINDEVENT) == DONE)){
-                    c3_used = true;
-                    go->Say("c3_activated", LANG_UNIVERSAL,player->GetGUID());
-                }
-
-                if (go->GetGUID() == consoles[4])
-                    if (!c4_used && (pInstance->GetData(DATA_KARATHRESSEVENT) == DONE)){
-                        c4_used = true;
-                        go->Say("c4_activated", LANG_UNIVERSAL,player->GetGUID());
-                    }
-
-                    if (go->GetGUID() == consoles[5])
-                        if (!c5_used && (pInstance->GetData(DATA_MOROGRIMTIDEWALKEREVENT) == DONE)){
-                            c5_used = true;
-                            go->Say("c5_activated", LANG_UNIVERSAL,player->GetGUID());
-                        }
-
-                        if (c1_used && c2_used && c3_used && c4_used && c5_used){
-                            if (player && ControlConsole)
-                                if (GameObject *go_console = GameObject::GetGameObject(*player,ControlConsole)){
-                                    go_console->SetGoState(GOState(0));
-                                    go->Say("all_activated", LANG_UNIVERSAL,player->GetGUID());
-                                    pInstance->SetData(DATA_CONTROL_CONSOLE, DONE);
-                                }
-                        }
-
-                        return true;
+    if (id == ConsoleGuids[0])
+    {
+        instance->SetData(DATA_HYDROSS_EVENT, SPECIAL);
+        player->TextEmote("activates console #1 [Hydross the Unstable].");
+        return true;
+    }
+    if (id == ConsoleGuids[1])
+    {
+        instance->SetData(DATA_LURKER_EVENT, SPECIAL);
+        player->TextEmote("activates console #2 [The Lurker Below].");
+        return true;
+    }
+    if (id == ConsoleGuids[2])
+    {
+        instance->SetData(DATA_LEOTHERAS_EVENT, SPECIAL);
+        player->TextEmote("activates console #3 [Leotheras the Blind].");
+        return true;
+    }
+    if (id == ConsoleGuids[3])
+    {
+        instance->SetData(DATA_KARATHRESS_EVENT, SPECIAL);
+        player->TextEmote("activates console #4 [Fathom-Lord Karathress].");
+        return true;
+    }
+    if (id == ConsoleGuids[4])
+    {
+        instance->SetData(DATA_MOROGRIM_EVENT, SPECIAL);
+        player->TextEmote("activates console #5 [Morogrim Tidewalker].");
+        return true;
+    }
+    if (id == BridgeConsoleGuid) {
+        instance->SetData(DATA_BRIDGE_CONSOLE, DONE);
+        player->TextEmote("activates console #6 [Access to Lady Vashj].");
+        return true;
+    }
+    return false;
 }
 
 struct instance_serpentshrine_cavern : public ScriptedInstance
 {
-    instance_serpentshrine_cavern(Map *map) : ScriptedInstance(map) {Initialize();};
+    instance_serpentshrine_cavern(Map *map) : ScriptedInstance(map)
+    {
+        Initialize();
+    };
 
-    uint64 LurkerBelow;
-    uint64 Sharkkis;
-    uint64 SharkkisPet;
-    uint64 Tidalvess;
-    uint64 Caribdis;
-    uint64 LadyVashj;
-    uint64 Karathress;
-    uint64 KarathressEvent_Starter;
-    uint64 LeotherasTheBlind;
-    uint64 LeotherasEventStarter;
+    /* Encounters */
+    uint32 Encounters[MAX_ENCOUNTER];
 
-    uint64 BridgePart[3];
-    uint32 StrangePool;
+    /* Creatures */
+    uint64 LurkerBelowGuid;
+    uint64 SharkkisGuid;
+    uint64 SharkkisPetGuid;
+    uint64 TidalvessGuid;
+    uint64 CaribdisGuid;
+    uint64 LadyVashjGuid;
+    uint64 KarathressGuid;
+    uint64 KarathressEventStarterGuid;
+    uint64 LeotherasTheBlindGuid;
+    uint64 LeotherasEventStarterGuid;
+
+    uint64 StrangePoolGuid;
+    uint64 BridgePartGuids[3];
     uint32 FishingTimer;
-    uint32 LurkerSubEvent;
+    uint32 FrenzySpawnTimer;
+    uint32 LurkerFishingEvent;
+    uint32 LurkerFishingInternalCooldown;
     uint32 WaterCheckTimer;
     uint32 Water;
-    uint32 trashCheckTimer;
+    uint32 TrashCheckTimer;
 
     bool ShieldGeneratorDeactivated[4];
-    uint32 Encounters[ENCOUNTERS];
+    bool DoSpawnFrenzy;
 
     void Initialize()
     {
-        LurkerBelow = 0;
-        Sharkkis = 0;
-        SharkkisPet = 0;
-        Tidalvess = 0;
-        Caribdis = 0;
-        LadyVashj = 0;
-        Karathress = 0;
-        KarathressEvent_Starter = 0;
-        LeotherasTheBlind = 0;
-        LeotherasEventStarter = 0;
+        // Set all encounters to EncounterState:NOT_STARTED (0)
+        memset(&Encounters, NOT_STARTED, sizeof(Encounters));
 
-        ControlConsole = 0;
-        BridgePart[0] = 0;
-        BridgePart[1] = 0;
-        BridgePart[2] = 0;
+        // Set Lurker Fishing Event to EncounterState:NOT_STARTED (0)
+        LurkerFishingEvent = NOT_STARTED;
 
-        StrangePool = 0;
+        // Set Lurker Fishing cooldown to 0
+        LurkerFishingInternalCooldown = 0;
+
+        // Strange pool gameobject GUID
+        StrangePoolGuid = 0;
+        
+        /* Creature GUIDs */
+        LurkerBelowGuid = 0;
+        SharkkisGuid = 0;
+        SharkkisPetGuid = 0;
+        TidalvessGuid = 0;
+        CaribdisGuid = 0;
+        LadyVashjGuid = 0;
+        KarathressGuid = 0;
+        KarathressEventStarterGuid = 0;
+        LeotherasTheBlindGuid = 0;
+        LeotherasEventStarterGuid = 0;
+
+        /* Console and Bridge Gameobjects */
+        memset(&ConsoleGuids, 0, sizeof(ConsoleGuids));
+        BridgeConsoleGuid = 0;
+        memset(&BridgePartGuids, 0, sizeof(BridgePartGuids));
+     
+
         Water = WATERSTATE_FRENZY;
-
         ShieldGeneratorDeactivated[0] = false;
         ShieldGeneratorDeactivated[1] = false;
         ShieldGeneratorDeactivated[2] = false;
         ShieldGeneratorDeactivated[3] = false;
-        FishingTimer = 1000;
-        LurkerSubEvent = 0;
         WaterCheckTimer = 500;
-        trashCheckTimer = 10000;
-
-        for(uint8 i = 0; i < ENCOUNTERS; i++)
-            Encounters[i] = NOT_STARTED;
-    }
-
-    bool IsEncounterInProgress() const
-    {
-        for(uint8 i = 0; i < ENCOUNTERS; i++)
-            if (Encounters[i] == IN_PROGRESS)
-                return true;
-
-        return false;
+        TrashCheckTimer = 10000;
     }
 
     void OnObjectCreate(GameObject *go)
     {
-        switch(go->GetEntry())
+        uint32 data = NOT_STARTED;
+        switch (go->GetEntry())
         {
-        case 184568:
-            ControlConsole = go->GetGUID();
-            if (c1_used && c2_used && c3_used && c4_used && c5_used)
-                HandleGameObject(ControlConsole, 0);
-            break;
-
-        case 184203:
-            BridgePart[0] = go->GetGUID();
-            go->setActive(true);
-            break;
-
-        case 184204:
-            BridgePart[1] = go->GetGUID();
-            go->setActive(true);
-            break;
-
-        case 184205:
-            BridgePart[2] = go->GetGUID();
-            go->setActive(true);
-            break;
-        case 184956:
-            StrangePool = go->GetGUID();
-            if(go->isActiveObject())
-                SetData(DATA_STRANGE_POOL, DONE);
-            break;
-        case GAMEOBJECT_FISHINGNODE_ENTRY:
-            if(LurkerSubEvent == LURKER_NOT_STARTED)
-            {
-                if (Unit *pTemp = instance->GetCreature(LurkerBelow))
+            case 185114: // Serpentshrine Console [Hydross the Lurker]
+                ConsoleGuids[0] = go->GetGUID();
+                data = GetData(DATA_HYDROSS_EVENT);
+                if ((data == DONE) || (data == SPECIAL))
                 {
-                    if (go->GetDistance2d(pTemp) > 16.0f)
-                        return;
-
-                    FishingTimer = 10000+rand()%30000;//random time before lurker emerges
-                    LurkerSubEvent = LURKER_FISHING;
+                    UnlockGameObject(ConsoleGuids[0]);
                 }
-            }
-            break;
+                break;
+            case 185115: // Serpentshrine Console [The Lurker Below]
+                ConsoleGuids[1] = go->GetGUID();
+                data = GetData(DATA_LURKER_EVENT);
+                if ((data == DONE) || (data == SPECIAL))
+                {
+                    UnlockGameObject(ConsoleGuids[1]);
+                }
+                break;
+            case 185116: // Serpentshrine Console [Leotheras the Blind]
+                ConsoleGuids[2] = go->GetGUID();
+                data = GetData(DATA_LEOTHERAS_EVENT);
+                if ((data == DONE) || (data == SPECIAL))
+                {
+                    UnlockGameObject(ConsoleGuids[2]);
+                }
+                break;
+            case 185117: // Serpentshrine Console [Fathom-Lord Karathress]
+                ConsoleGuids[3] = go->GetGUID();
+                data = GetData(DATA_KARATHRESS_EVENT);
+                if ((data == DONE) || (data == SPECIAL))
+                {
+                    UnlockGameObject(ConsoleGuids[3]);
+                }
+                break;
+            case 185118: // Serpentshrine Console [Morogrim Tidewalker]
+                ConsoleGuids[4] = go->GetGUID();
+                data = GetData(DATA_MOROGRIM_EVENT);
+                if ((data == DONE) || (data == SPECIAL))
+                {
+                    UnlockGameObject(ConsoleGuids[4]);
+                }
+                break;
+            case 184568: // Lady Vashj Bridge Console
+                BridgeConsoleGuid = go->GetGUID();
+                if (AllSerpentshrineConsolesActivated())
+                {
+                    UnlockGameObject(BridgeConsoleGuid); 
+                }  
+                break;
+            case 184203: // Doodad_Coilfang_Raid_Bridge_Part01
+                BridgePartGuids[0] = go->GetGUID();
+                break;
+            case 184204: // Doodad_Coilfang_Raid_Bridge_Part02
+                BridgePartGuids[1] = go->GetGUID();
+                break;
+            case 184205: // Doodad_Coilfang_Raid_Bridge_Part03
+                BridgePartGuids[2] = go->GetGUID();
+                break;
+            case 184956: // Strange Pool
+                StrangePoolGuid = go->GetGUID();
+                break;
+            case GAMEOBJECT_FISHINGNODE_ENTRY: // Fishing Bobber
+                if(LurkerFishingEvent == NOT_STARTED)
+                {
+                    if (Unit *lurker = instance->GetCreature(LurkerBelowGuid))
+                    {
+                        if (go->GetDistance2d(lurker) > 16.0f)
+                        {
+                            return;
+                        }
+                        if (LurkerFishingInternalCooldown > 0)
+                        {
+                            return;
+                        }
 
-        case 185114:
-            consoles[1] = go->GetGUID();
-            go->setActive(true);
-            break;
+                        Player *player = (Player*) go->GetOwner();
+                        uint32 FishingLevel = player->GetSkillValue(SKILL_FISHING);
 
-        case 185118:
-            consoles[5] = go->GetGUID();
-            go->setActive(true);
-            break;
+                        if (FishingLevel < 300)
+                        {
+                            return;
+                        }
 
-        case 185115:
-            consoles[2] = go->GetGUID();
-            go->setActive(true);
-            break;
+                        uint32 chance = static_cast<unsigned int>((exp(0.013 * FishingLevel) * 0.1) + 0.5);
+                        uint32 rand = urand(1, 100);
 
-        case 185116:
-            consoles[3] = go->GetGUID();
-            go->setActive(true);
-            break;
-
-        case 185117:
-            consoles[4] = go->GetGUID();
-            go->setActive(true);
-            break;
-        }
-    }
-
-    void OpenDoor(uint64 DoorGUID, bool open)
-    {
-        if(GameObject *Door = instance->GetGameObject(DoorGUID))
-            Door->SetUInt32Value(GAMEOBJECT_STATE, open ? 0 : 1);
-    }
-
-    uint32 GetEncounterForEntry(uint32 entry)
-    {
-        switch(entry)
-        {
-        case 21212:
-            return DATA_LADYVASHJEVENT;
-        case 21214:
-            return DATA_KARATHRESSEVENT;
-        case 21217:
-            return DATA_THELURKERBELOWEVENT;
-        case 21215:
-            return DATA_LEOTHERASTHEBLINDEVENT;
-        case 21213:
-            return DATA_MOROGRIMTIDEWALKEREVENT;
-        case 21216:
-            return DATA_HYDROSSTHEUNSTABLEEVENT;
-        default:
-            return 0;
+                        if (rand <= chance)
+                        {   
+                            player->TextEmote("casts their lure into the strange pool and disturbs a creature in the shadowy depths below...");
+                            SetData(DATA_LURKER_FISHING_EVENT, DONE);
+                        }
+                        else
+                        {
+                            player->TextEmote("casts their lure into the strange pool expectantly.");
+                        }
+                        LurkerFishingInternalCooldown = LURKER_FISHING_INTERNAL_COOLDOWN;
+                    }
+                }
+                break;
         }
     }
 
@@ -280,152 +271,235 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
     {
         switch(creature_entry)
         {
-        case 21212:
-            LadyVashj = creature->GetGUID();
-            break;
-        case 21214:
-            Karathress = creature->GetGUID();
-            break;
-        case 21966:
-            Sharkkis = creature->GetGUID();
-            break;
-        case 21217:
-            LurkerBelow = creature->GetGUID();
-            break;
-        case 21965:
-            Tidalvess = creature->GetGUID();
-            break;
-        case 21964:
-            Caribdis = creature->GetGUID();
-            break;
-        case 21215:
-            LeotherasTheBlind = creature->GetGUID();
-            break;
+            case 21212:
+                LadyVashjGuid = creature->GetGUID();
+                break;
+            case 21214:
+                KarathressGuid = creature->GetGUID();
+                break;
+            case 21966:
+                SharkkisGuid = creature->GetGUID();
+                break;
+            case 21217:
+                LurkerBelowGuid = creature->GetGUID();
+                break;
+            case 21965:
+                TidalvessGuid = creature->GetGUID();
+                break;
+            case 21964:
+                CaribdisGuid = creature->GetGUID();
+                break;
+            case 21215:
+                LeotherasTheBlindGuid = creature->GetGUID();
+                break;
         }
-
         HandleInitCreatureState(creature);
     }
 
-    void SetData64(uint32 type, uint64 data)
+    void OpenDoor(uint64 DoorGUID, bool open)
     {
-        if(type == DATA_KARATHRESSEVENT_STARTER)
-            KarathressEvent_Starter = data;
-        if(type == DATA_LEOTHERAS_EVENT_STARTER)
-            LeotherasEventStarter = data;
-        if(type == DATA_SHARKKIS_PET)
-            SharkkisPet = data;
+        if (GameObject *Door = instance->GetGameObject(DoorGUID))
+        {
+            Door->SetUInt32Value(GAMEOBJECT_STATE, open ? 0 : 1);
+        }
     }
 
-    uint64 GetData64(uint32 identifier)
+    void UnlockGameObject(uint64 GameObjectGUID)
     {
-        switch(identifier)
+        if (GameObject *go = instance->GetGameObject(GameObjectGUID)) 
         {
-        case DATA_THELURKERBELOW:           return LurkerBelow;
-        case DATA_SHARKKIS:                 return Sharkkis;
-        case DATA_SHARKKIS_PET:             return SharkkisPet;
-        case DATA_TIDALVESS:                return Tidalvess;
-        case DATA_CARIBDIS:                 return Caribdis;
-        case DATA_LADYVASHJ:                return LadyVashj;
-        case DATA_KARATHRESS:               return Karathress;
-        case DATA_KARATHRESSEVENT_STARTER:  return KarathressEvent_Starter;
-        case DATA_LEOTHERAS:                return LeotherasTheBlind;
-        case DATA_LEOTHERAS_EVENT_STARTER:  return LeotherasEventStarter;
+            go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         }
-        return 0;
+    }
+    
+    bool AllSerpentshrineConsolesActivated()
+    {
+        return ((GetData(DATA_HYDROSS_EVENT) == SPECIAL) &&
+                (GetData(DATA_LURKER_EVENT) == SPECIAL) &&
+                (GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) &&
+                (GetData(DATA_KARATHRESS_EVENT) == SPECIAL) &&
+                (GetData(DATA_MOROGRIM_EVENT) == SPECIAL));
     }
 
     void SetData(uint32 type, uint32 data)
     {
         switch(type)
         {
-        case DATA_STRANGE_POOL:
-            {
-                StrangePool = data;
-                if(data == NOT_STARTED)
-                    LurkerSubEvent = LURKER_NOT_STARTED;
-            }
-            break;
-        case DATA_WATER : Water = data; break;
-        case DATA_CONTROL_CONSOLE:
-            if(data == DONE)
-            {
-                OpenDoor(BridgePart[0], true);
-                OpenDoor(BridgePart[1], true);
-                OpenDoor(BridgePart[2], true);
-            }
-            ControlConsole = data;
-            break;
-        case DATA_HYDROSSTHEUNSTABLEEVENT:
-            if(Encounters[0] != DONE)
+            case DATA_HYDROSS_EVENT:
                 Encounters[0] = data;
-            break;
-        case DATA_LEOTHERASTHEBLINDEVENT:
-            if(Encounters[1] != DONE)
+                if (data == DONE)
+                {
+                    UnlockGameObject(ConsoleGuids[0]);           
+                }
+                if ((data == SPECIAL) && (AllSerpentshrineConsolesActivated()))
+                {
+                    UnlockGameObject(BridgeConsoleGuid); 
+                }     
+                break;
+            case DATA_LURKER_EVENT:
                 Encounters[1] = data;
-            break;
-        case DATA_THELURKERBELOWEVENT:
-            if(Encounters[2] != DONE)
+                if (data == DONE)
+                {
+                    UnlockGameObject(ConsoleGuids[1]);           
+                }
+                if ((data == SPECIAL) && (AllSerpentshrineConsolesActivated()))
+                {
+                    UnlockGameObject(BridgeConsoleGuid); 
+                }     
+                break;
+            case DATA_LEOTHERAS_EVENT:
                 Encounters[2] = data;
-            break;
-        case DATA_KARATHRESSEVENT:
-            if(Encounters[3] != DONE)
+                if (data == DONE)
+                {
+                    UnlockGameObject(ConsoleGuids[2]);           
+                }
+                if ((data == SPECIAL) && (AllSerpentshrineConsolesActivated()))
+                {
+                    UnlockGameObject(BridgeConsoleGuid); 
+                }     
+                break;
+            case DATA_KARATHRESS_EVENT:
                 Encounters[3] = data;
-            break;
-        case DATA_MOROGRIMTIDEWALKEREVENT:
-            if(Encounters[4] != DONE)
+                if (data == DONE)
+                {
+                    UnlockGameObject(ConsoleGuids[3]);           
+                }
+                if ((data == SPECIAL) && (AllSerpentshrineConsolesActivated()))
+                {
+                    UnlockGameObject(BridgeConsoleGuid); 
+                }     
+                break;
+            case DATA_MOROGRIM_EVENT:
                 Encounters[4] = data;
-            break;
-            //Lady Vashj
-        case DATA_LADYVASHJEVENT:
-            if(data == NOT_STARTED)
-            {
-                ShieldGeneratorDeactivated[0] = false;
-                ShieldGeneratorDeactivated[1] = false;
-                ShieldGeneratorDeactivated[2] = false;
-                ShieldGeneratorDeactivated[3] = false;
-            }
-            if (Encounters[5] != DONE)
+                if (data == DONE)
+                {
+                    UnlockGameObject(ConsoleGuids[4]);           
+                }
+                if ((data == SPECIAL) && (AllSerpentshrineConsolesActivated()))
+                {
+                    UnlockGameObject(BridgeConsoleGuid); 
+                }     
+                break;
+            case DATA_VASHJ_EVENT:
                 Encounters[5] = data;
-            break;
-        case DATA_SHIELDGENERATOR1:ShieldGeneratorDeactivated[0] = (data) ? true : false;   break;
-        case DATA_SHIELDGENERATOR2:ShieldGeneratorDeactivated[1] = (data) ? true : false;   break;
-        case DATA_SHIELDGENERATOR3:ShieldGeneratorDeactivated[2] = (data) ? true : false;   break;
-        case DATA_SHIELDGENERATOR4:ShieldGeneratorDeactivated[3] = (data) ? true : false;   break;
+                if(data == NOT_STARTED)
+                {
+                    ShieldGeneratorDeactivated[0] = false;
+                    ShieldGeneratorDeactivated[1] = false;
+                    ShieldGeneratorDeactivated[2] = false;
+                    ShieldGeneratorDeactivated[3] = false;
+                }
+                break;
+            case DATA_SHIELD_GENERATOR_ONE:
+                ShieldGeneratorDeactivated[0] = (data) ? true : false; break;
+            case DATA_SHIELD_GENERATOR_TWO:
+                ShieldGeneratorDeactivated[1] = (data) ? true : false; break;
+            case DATA_SHIELD_GENERATOR_THREE:
+                ShieldGeneratorDeactivated[2] = (data) ? true : false; break;
+            case DATA_SHIELD_GENERATOR_FOUR:
+                ShieldGeneratorDeactivated[3] = (data) ? true : false; break;
+            case DATA_BRIDGE_CONSOLE:
+                OpenDoor(BridgeConsoleGuid, true);
+                OpenDoor(BridgePartGuids[0], true);
+                OpenDoor(BridgePartGuids[1], true);
+                OpenDoor(BridgePartGuids[2], true);
+                break;
+            case DATA_LURKER_FISHING_EVENT:
+                LurkerFishingEvent = data;
+                break;
         }
 
-        if (data == DONE)
+        if (data == DONE || data == SPECIAL)
+        {
             SaveToDB();
+        }
     }
 
     uint32 GetData(uint32 type)
     {
         switch(type)
         {
-        case DATA_HYDROSSTHEUNSTABLEEVENT:  return Encounters[0];
-        case DATA_LEOTHERASTHEBLINDEVENT:   return Encounters[1];
-        case DATA_THELURKERBELOWEVENT:      return Encounters[2];
-        case DATA_KARATHRESSEVENT:          return Encounters[3];
-        case DATA_MOROGRIMTIDEWALKEREVENT:  return Encounters[4];
-            //Lady Vashj
-        case DATA_LADYVASHJEVENT:           return Encounters[5];
-        case DATA_SHIELDGENERATOR1:         return ShieldGeneratorDeactivated[0];
-        case DATA_SHIELDGENERATOR2:         return ShieldGeneratorDeactivated[1];
-        case DATA_SHIELDGENERATOR3:         return ShieldGeneratorDeactivated[2];
-        case DATA_SHIELDGENERATOR4:         return ShieldGeneratorDeactivated[3];
-        case DATA_CANSTARTPHASE3:
-            if (ShieldGeneratorDeactivated[0] && ShieldGeneratorDeactivated[1] && ShieldGeneratorDeactivated[2] && ShieldGeneratorDeactivated[3])
-                return 1;
-            break;
-        case DATA_STRANGE_POOL:             return StrangePool;
-        case DATA_WATER:                    return Water;
+            case DATA_HYDROSS_EVENT:
+                return Encounters[0];
+            case DATA_LURKER_EVENT:
+                return Encounters[1];
+            case DATA_LEOTHERAS_EVENT:
+                return Encounters[2];
+            case DATA_KARATHRESS_EVENT:
+                return Encounters[3];
+            case DATA_MOROGRIM_EVENT:
+                return Encounters[4];
+            case DATA_VASHJ_EVENT:
+                return Encounters[5];
+            case DATA_SHIELD_GENERATOR_ONE:
+                return ShieldGeneratorDeactivated[0];
+            case DATA_SHIELD_GENERATOR_TWO:
+                return ShieldGeneratorDeactivated[1];
+            case DATA_SHIELD_GENERATOR_THREE:
+                return ShieldGeneratorDeactivated[2];
+            case DATA_SHIELD_GENERATOR_FOUR:
+                return ShieldGeneratorDeactivated[3];
+            case DATA_LURKER_FISHING_EVENT:
+                return LurkerFishingEvent;
+            case DATA_CAN_START_PHASE_3:
+                if (ShieldGeneratorDeactivated[0] && ShieldGeneratorDeactivated[1] && ShieldGeneratorDeactivated[2] && ShieldGeneratorDeactivated[3])
+                {
+                    return 1;
+                }
+            default:
+                return 0;
         }
-        return 0;
+    }
+
+    void SetData64(uint32 type, uint64 data)
+    {
+        switch(type)
+        {
+            case DATA_KARATHRESS_EVENT_STARTER:
+                KarathressEventStarterGuid = data;
+                break;
+            case DATA_LEOTHERAS_EVENT_STARTER:
+                LeotherasEventStarterGuid = data;
+                break;
+            case DATA_SHARKKIS_PET:
+                SharkkisPetGuid = data;
+                break;
+        }
+    }
+
+    uint64 GetData64(uint32 type)
+    {
+        switch(type)
+        {
+            case DATA_LURKER:
+                return LurkerBelowGuid;
+            case DATA_LEOTHERAS:
+                return LeotherasTheBlindGuid;
+            case DATA_KARATHRESS:
+                return KarathressGuid;
+            case DATA_VASHJ:
+                return LadyVashjGuid;
+            case DATA_SHARKKIS:
+                return SharkkisGuid;
+            case DATA_TIDALVESS:
+                return TidalvessGuid;
+            case DATA_CARIBDIS:
+                return CaribdisGuid;
+            case DATA_SHARKKIS_PET:
+                return SharkkisPetGuid;
+            case DATA_LEOTHERAS_EVENT_STARTER:
+                return LeotherasEventStarterGuid;
+            case DATA_KARATHRESS_EVENT_STARTER:
+                return KarathressEventStarterGuid;
+            default:
+                return 0;
+        }
     }
 
     std::string GetSaveData()
     {
         OUT_SAVE_INST_DATA;
-
+        
         std::ostringstream stream;
         stream << Encounters[0] << " ";
         stream << Encounters[1] << " ";
@@ -441,57 +515,71 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
 
     void Load(const char* in)
     {
-        if(!in)
+        if (!in)
         {
             OUT_LOAD_INST_DATA_FAIL;
             return;
         }
+
         OUT_LOAD_INST_DATA(in);
         std::istringstream stream(in);
         stream >> Encounters[0] >> Encounters[1] >> Encounters[2] >> Encounters[3]
         >> Encounters[4] >> Encounters[5];
-        for(uint8 i = 0; i < ENCOUNTERS; ++i)
-            if(Encounters[i] == IN_PROGRESS)                // Do not load an encounter as "In Progress" - reset it instead.
+
+        for(uint8 i = 0; i < sizeof(Encounters); ++i)
+        {
+            if (Encounters[i] == IN_PROGRESS) // Do not load an encounter as "In Progress" - reset it instead.
+            {
                 Encounters[i] = NOT_STARTED;
+            }
+        }
+
         OUT_LOAD_INST_DATA_COMPLETE;
     }
 
-    void Update (uint32 diff)
+    void Update(uint32 diff)
     {
-        //Lurker Fishing event
-        if (LurkerSubEvent == LURKER_FISHING)
+        // If time left on LurkerFishingInternalCooldown is less than the update diff (usually 100ms~)
+        // Then set it to 0, allowing further fishing
+        // Else lower it closer to 0
+        if (LurkerFishingInternalCooldown < diff)
         {
-            if (FishingTimer < diff)
-            {
-                LurkerSubEvent = LURKER_HOOKED;
-                SetData(DATA_STRANGE_POOL, IN_PROGRESS);//just fished, signal Lurker script to emerge and start fight, we use IN_PROGRESS so it won't get saved and lurker will be alway invis at start if server restarted
-            }
-            else
-                FishingTimer -= diff;
+            LurkerFishingInternalCooldown = 0;
+        }
+        else
+        {
+            LurkerFishingInternalCooldown -= diff;
         }
 
-        if (trashCheckTimer < diff)
+        // If time left on TrashCheckTimer is less than the update diff (usually 100ms~)
+        if (TrashCheckTimer < diff)
         {
-            if (Encounters[2] == NOT_STARTED)
+            // If Lurker has not been started
+            if (Encounters[1] == NOT_STARTED)
             {
-                //uint64 tmpPriestessGuid = instance->GetCreatureGUID(TRASHMOB_COILFANG_PRIESTESS, GET_ALIVE_CREATURE_GUID);
-                uint64 tmpTechniGuid = instance->GetCreatureGUID(TRASHMOB_COILFANG_TECHNI, GET_ALIVE_CREATURE_GUID);
-                if (/*!tmpPriestessGuid && */!tmpTechniGuid)
+                // If there are no Technicians alive
+                // Then make the water scalding
+                // Else make the water frenzied
+                uint64 GreyheartTechnicianGuid = instance->GetCreatureGUID(MOB_GREYHEART_TECHNICIAN, GET_ALIVE_CREATURE_GUID);
+                if (!GreyheartTechnicianGuid)
                     Water = WATERSTATE_SCALDING;
                 else
                     Water = WATERSTATE_FRENZY;
             }
-            else if (Encounters[2] == DONE)
+            // If Lurker has been completed
+            // Then make the water normal
+            else if ((Encounters[1] == DONE) || (Encounters[1] == SPECIAL))
             {
                 Water = WATERSTATE_NONE;
             }
-
-            trashCheckTimer = 2000;
+            TrashCheckTimer = 2000;
         }
         else
-            trashCheckTimer -= diff;
+        {
+            TrashCheckTimer -= diff;
+        }
 
-        //Water checks
+        // If time left on WaterCheckTimer is less than the update diff (usually 100ms~)
         if (WaterCheckTimer < diff)
         {
             Map::PlayerList const &PlayerList = instance->GetPlayers();
@@ -533,7 +621,10 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
             WaterCheckTimer = 1500;
         }
         else
+        {
             WaterCheckTimer -= diff;
+        }
+
     }
 };
 
@@ -550,12 +641,7 @@ void AddSC_instance_serpentshrine_cavern()
     newscript->Name = "instance_serpent_shrine";
     newscript->GetInstanceData = &GetInstanceData_instance_serpentshrine_cavern;
     newscript->RegisterSelf();
-    /*
-    newscript = new Script;
-    newscript->Name="go_bridge_console";
-    newscript->pGOUse = &GOUse_go_bridge_console;
-    newscript->RegisterSelf();
-    */
+
     newscript = new Script;
     newscript->Name="GOUse_go_vashj_console_access_panel";
     newscript->pGOUse = &GOUse_go_vashj_console_access_panel;


### PR DESCRIPTION
#### Features
* 5 consoles (1 by each boss prior to Vashj) require activation to unlock Lady Vashj Bridge Console
* each console is locked by default (unlocks upon boss kill)
* Lurker event requires 300+ fishing to start (approx. 5% chance at 300, increasing up to 100% with max fishing + boosts)

---

It may be more prudent to figure out what is causing the difference between how certain bosses behave on different environments (i.e. local machine vs PTR) than simply reverting large pull requests such as this.

Note: Greyheart spellbinders by Leotheras will now engage with attackers allowing Leotheras encounter to begin (this was an issue with the SetData64 function expecting an ObjectGuid instead of uint64). Whilst I've reverted to the use of uint64 in most cases. ObjectGuid could be something worth looking into if we wish to standardise our scripts across the board for future T5 and T6 content.