### PR TITLE
Update boss_lady_vashj_EnchantedElemental_Timer_3.cpp

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lady_vashj.cpp
@@ -613,7 +613,7 @@ struct boss_lady_vashjAI : public ScriptedAI
                 }
 
                 if (Elemental)
-                    EnchantedElemental_Timer = 10000+rand()%5000;
+                    EnchantedElemental_Timer = urand(15000,25000);
 
             }
             else


### PR DESCRIPTION
https://github.com/Looking4Group/L4G_Core/pull/26

The way it is scripted the value needs to be alittle bit higher.

http://www.wowhead.com/npc=21958/enchanted-elemental#comments

By Rabidfire (3,898 – 5·30) on 2007/08/13 (Patch 2.1.3)

These are the adds that spawn every 10 seconds on each of the 4 sides during Lady Vashj Phase 2.