### PR TITLE
Kael'thas Sunstrider Aggro Range

### DIFF
--- a/src/scripts/scripts/zone/tempest_keep/the_eye/boss_kaelthas.cpp
+++ b/src/scripts/scripts/zone/tempest_keep/the_eye/boss_kaelthas.cpp
@@ -25,6 +25,8 @@ EndScriptData */
 #include "def_the_eye.h"
 #include "WorldPacket.h"
 
+#define AGGRO_RANGE                           40.0
+
 //kael'thas Speech
 #define SAY_INTRO                         -1550016
 #define SAY_INTRO_CAPERNIAN               -1550017
@@ -318,6 +320,7 @@ struct boss_kaelthasAI : public ScriptedAI
 {
     boss_kaelthasAI(Creature *c) : ScriptedAI(c), summons(m_creature)
     {
+        m_creature->SetAggroRange(AGGRO_RANGE);
         pInstance = (c->GetInstanceData());
 
         for(int i = 0; i < 4; i++)


### PR DESCRIPTION
https://youtu.be/9tt3T5vVDMM?t=26s

Follow the Bloodelf running towards Kael'thas triggering the Event.
Because of the jumping you see where he crosses the floor lines, making it easier to guess where the aggro range is set.
26 is when the Speech begins.