### PR TITLE
Script/Kaelthas: Telonicus, timing, and misc. fixes

### DIFF
--- a/sql/updates/world/059_kaelthas_polishing.sql
+++ b/sql/updates/world/059_kaelthas_polishing.sql
@@ -1,0 +1,2 @@
+-- Kael'thas Advisor Thaladred the Darkener Gaze Emote Update
+UPDATE `script_texts` SET `content_default`='sets his eyes on $N!' WHERE `entry` = -1550037;


### PR DESCRIPTION
#### Telonicus fixes
* If his target (highest on the threat table) is within 15 yards he will behave as he previously did. Bombing every 2 to 8 seconds etc. and attempting to melee
* If his target is farther than 15 yards away (but closer than 30 yards) he will bomb the target every 2 seconds
* If his target is farther than 30 yards away he will move towards them until one of the above two conditions is met

#### Timing fixes
* Thaladred gaze duration randomised between 9 to 15 seconds
 * 9 to 15 seconds seemed to be the most accurate timings I could find from watching various kill videos
* Capernian will now cast conflagration 11-15 seconds after entering combat
 * 11 to 15 seconds seemed to be the most accurate timings I could find from watching various kill videos
* Capernian's conflagration spell now has a 14-16 second cooldown
 * 14 to 16 seconds seemed to be the most accurate timings I could find from watching various kill videos

#### Misc. fixes
* Advisors now resets their threat tables when revived at the start of phase 3
* Thaladred now has the correct gaze emote (gaze -> eyes)
* There is now a seven second delay between the start of phase 3 (the yell) and the advisors being revived
 * I am tempted to increase this to allow him to actually finish his yell, currently Capernian will yell over him when she spawns which is no fun :-1: 

----

Everything tested locally. Requires further testing on PTR.