### PR TITLE
lower_tidewalker_aggrorange

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_morogrim_tidewalker.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_morogrim_tidewalker.cpp
@@ -24,7 +24,7 @@ EndScriptData */
 #include "precompiled.h"
 #include "def_serpent_shrine.h"
 
-#define AGGRO_RANGE                     45.0
+#define AGGRO_RANGE                     40.0
 
 #define SAY_AGGRO                   -1548030
 #define SAY_SUMMON1                 -1548031


### PR DESCRIPTION
45y probably too high.
40y looks still fine.
on live raid could pull all trash packs without adding boss