### PR TITLE
Type change from ObjectGuid to uint64

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
@@ -33,8 +33,8 @@ EndScriptData */
 5 - Lady Vashj
 */
 
-ObjectGuid ConsoleGuids[5]; 
-ObjectGuid BridgeConsoleGuid;
+uint64 ConsoleGuids[5]; 
+uint64 BridgeConsoleGuid;
 
 bool GOUse_go_vashj_console_access_panel(Player *player, GameObject* go)
 {
@@ -45,8 +45,7 @@ bool GOUse_go_vashj_console_access_panel(Player *player, GameObject* go)
         return false;
     }
 
-    ObjectGuid id;
-    id = go->GetGUID();
+    uint64 id = go->GetGUID();
 
     if (id == ConsoleGuids[0])
     {


### PR DESCRIPTION
Simple change from `ObjectGuid` to `uint64` type for SSC consoles. `ObjectGuid` was causing inconsistencies during my testing and these were left over.