### PR TITLE
SSC/Trash: hackfix_interrupt_underbogColossus

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -1246,6 +1246,15 @@ void Spell::DoSpellHitOnUnit(Unit *unit, const uint32 effectMask)
         if (unit->GetEntry() == 17767 && GetSpellInfo()->Effect[effectNumber] == SPELL_EFFECT_CHARGE)
             continue;
 
+        //Hack for underbog colossus ACID_GEYSER - don't interrupt with intercept
+        if (unit->HasAura(38971) && GetSpellInfo()->Effect[effectNumber] == SPELL_EFFECT_CHARGE)
+            continue;
+
+        //Hack for underbog colossus SPORE_QUAKE  - don't interrupt with intercept
+        if (unit->HasAura(38976) && GetSpellInfo()->Effect[effectNumber] == SPELL_EFFECT_CHARGE)
+            continue;
+
+
         if (effectMask & (1<<effectNumber))
             HandleEffects(unit,NULL,NULL,effectNumber/*,m_damageMultipliers[effectNumber]*/);
     }
@@ -2320,6 +2329,24 @@ void Spell::prepare(SpellCastTargets * targets, Aura* triggeredByAura)
         if (m_targets.getUnitTarget())               //Deathcoil                                //Maim                       //Intercept
             if ((GetSpellInfo()->Effect[0] == SPELL_EFFECT_HEALTH_LEECH || GetSpellInfo()->Id == 22570 || GetSpellInfo()->Id == 25275)
                 && m_targets.getUnitTarget()->HasAura(43383))
+            {
+                SendCastResult(SPELL_FAILED_NOT_READY);
+                finish(false);
+                return;
+            }
+        //Hack for Underbog Colossus SPORE_QUAKE - don't interrupt with death coil, Maim, Intercept
+        if (m_targets.getUnitTarget())               //Deathcoil                                //Maim                       //Intercept
+            if ((GetSpellInfo()->Effect[0] == SPELL_EFFECT_HEALTH_LEECH || GetSpellInfo()->Id == 22570 || GetSpellInfo()->Id == 25275)
+                && m_targets.getUnitTarget()->HasAura(38976))
+            {
+                SendCastResult(SPELL_FAILED_NOT_READY);
+                finish(false);
+                return;
+            }
+        //Hack for Underbog Colossus ACID_GEYSER  - don't interrupt with death coil, Maim, Intercept
+        if (m_targets.getUnitTarget())               //Deathcoil                                //Maim                       //Intercept
+            if ((GetSpellInfo()->Effect[0] == SPELL_EFFECT_HEALTH_LEECH || GetSpellInfo()->Id == 22570 || GetSpellInfo()->Id == 25275)
+                && m_targets.getUnitTarget()->HasAura(38971))
             {
                 SendCastResult(SPELL_FAILED_NOT_READY);
                 finish(false);

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3475,6 +3475,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->AttributesEx2 &= ~SPELL_ATTR_EX2_IGNORE_LOS;
                 break;
             case 43383: // Spirit Bolts (HexLord)
+            case 38976: // Underbog Colossus SPORE_QUAKE
                 spellInfo->ChannelInterruptFlags |= CHANNEL_INTERRUPT_FLAG_MOVEMENT;
                 spellInfo->InterruptFlags &= ~SPELL_INTERRUPT_FLAG_INTERRUPT;
                 break;
@@ -3604,6 +3605,8 @@ void SpellMgr::LoadSpellCustomAttr()
                 break;
             case 38971: //acid geysir - spell of ssc colosses
                 spellInfo->EffectBasePoints[0] = 2478;
+                spellInfo->ChannelInterruptFlags |= CHANNEL_INTERRUPT_FLAG_MOVEMENT;
+                spellInfo->InterruptFlags &= ~SPELL_INTERRUPT_FLAG_INTERRUPT;
                 break;
             case 39045: //SPELL_SUMMON_SERPENTSHRINE_PARASITE
                 spellInfo->AreaId = 3607;


### PR DESCRIPTION
hackfix to prevent underbog collosus interruption while casting acid
geysir and spore quake.

probably very bad hackfix with unecessary parts - feel free to improve.
(but atleast it's working - tested local)