### PR TITLE
SSC/Trash: Hotfix_respawn_linking

### DIFF
--- a/sql/updates/world/071_hotfix_trash_respawn_ssc.sql
+++ b/sql/updates/world/071_hotfix_trash_respawn_ssc.sql
@@ -1,0 +1,5 @@
+INSERT INTO `creature_linked_respawn` VALUES
+(37951,93846),
+(37989,93846),
+(37987,93846),
+(37991,93846);

--- a/sql/updates/world/071_hotfix_trash_respawn_ssc.sql
+++ b/sql/updates/world/071_hotfix_trash_respawn_ssc.sql
@@ -1,3 +1,4 @@
+DELETE FROM `creature_linked_respawn` WHERE `guid` IN (37951,37989,37987,37991);
 INSERT INTO `creature_linked_respawn` VALUES
 (37951,93846),
 (37989,93846),


### PR DESCRIPTION
changed respawn link of first 4 trash npcs in SSC from vashj to hydross
guids: 37951,37989,37987,37991