### PR TITLE
Cataclysmic Bolt Targeting

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_fathomlord_karathress.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_fathomlord_karathress.cpp
@@ -308,8 +308,8 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
         //CataclysmicBolt_Timer
         if(CataclysmicBolt_Timer < diff)
         {
-            //Exlude Tank and targets without mana, if there aren't other units, cast on the tank
-            if(Unit *target = SelectUnit(SELECT_TARGET_RANDOM, 1, GetSpellMaxRange(SPELL_CATACLYSMIC_BOLT), true, POWER_MANA))
+            //Exlude targets without mana, if there aren't other units, cast on the tank
+            if(Unit *target = SelectUnit(SELECT_TARGET_RANDOM, 0, GetSpellMaxRange(SPELL_CATACLYSMIC_BOLT), true, POWER_MANA))
                 DoCast(target, SPELL_CATACLYSMIC_BOLT);
             else
                 DoCast(m_creature->getVictim(), SPELL_CATACLYSMIC_BOLT);


### PR DESCRIPTION
http://wowwiki.wikia.com/wiki/Fathom-Lord_Karathress , http://wowwiki.wikia.com/wiki/Fathom-Lord_Karathress?oldid=1627352

Due to the mechanics of Fathom-Lord's Cataclysmic Bolt, paladin tanks are not advisable for this fight. Damage caused by this ability to a tank with ~18-20k health is very difficult to heal through and can easily cause a wipe for entire raid.