### PR TITLE
Core/Player: Falldamage adjustment

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -20857,7 +20857,7 @@ bool ItemPosCount::isContainedIn(ItemPosCountVec const& vec) const
 
 void Player::HandleFallDamage(MovementInfo& movementInfo)
 {
-    if (movementInfo.GetFallTime() < 500)
+    if (movementInfo.GetFallTime() < 200)
         return;
 
     // calculate total z distance of the fall

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -20857,7 +20857,7 @@ bool ItemPosCount::isContainedIn(ItemPosCountVec const& vec) const
 
 void Player::HandleFallDamage(MovementInfo& movementInfo)
 {
-    if (movementInfo.GetFallTime() < 1500)
+    if (movementInfo.GetFallTime() < 500)
         return;
 
     // calculate total z distance of the fall
@@ -20866,8 +20866,8 @@ void Player::HandleFallDamage(MovementInfo& movementInfo)
     sLog.outDebug("zDiff = %f", z_diff);
 
     //Players with low fall distance, Feather Fall or physical immunity (charges used) are ignored
-    // 14.57 can be calculated by resolving damageperc formular below to 0
-    if (z_diff >= 14.57f && !isDead() && !isGameMaster() &&
+    // 13.47 can be calculated by resolving damageperc formular below to 0
+    if (z_diff >= 13.47f && !isDead() && !isGameMaster() &&
         !HasAuraType(SPELL_AURA_HOVER) && !HasAuraType(SPELL_AURA_FEATHER_FALL) &&
         !(HasAuraType(SPELL_AURA_FLY) && areaID != 550) && !IsImmunedToDamage(SPELL_SCHOOL_MASK_NORMAL,true))  //do not check for fly aura in Tempest Keep:Eye to properly deal fall dmg when after knockback (Gravity Lapse)
     {

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -20857,8 +20857,7 @@ bool ItemPosCount::isContainedIn(ItemPosCountVec const& vec) const
 
 void Player::HandleFallDamage(MovementInfo& movementInfo)
 {
-    if (movementInfo.GetFallTime() < 200)
-        return;
+    /*if (movementInfo.GetFallTime() < 200)
 
     // calculate total z distance of the fall
     float z_diff = m_lastFallZ - movementInfo.GetPos()->z;

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -20858,6 +20858,7 @@ bool ItemPosCount::isContainedIn(ItemPosCountVec const& vec) const
 void Player::HandleFallDamage(MovementInfo& movementInfo)
 {
     /*if (movementInfo.GetFallTime() < 200)
+        return;                                 not needed anymore*/
 
     // calculate total z distance of the fall
     float z_diff = m_lastFallZ - movementInfo.GetPos()->z;


### PR DESCRIPTION
damageperc = 0.018f*(z_diff-safe_fall)-0.2426f
for
damageperc = 0
min height is 13.47

also reduce GetFallTime from 1500 to 500 for better falldamage
before: got falldamage only at about 21+y
now: better waaay better (~13,5y with new min value)