### PR TITLE
Move Akil'zon Gauntlet Start Function

### DIFF
--- a/src/scripts/scripts/zone/zulaman/zulaman.cpp
+++ b/src/scripts/scripts/zone/zulaman/zulaman.cpp
@@ -960,6 +960,19 @@ struct npc_amanishi_lookoutAI : public ScriptedAI
 
     void EnterCombat(Unit *who)
     {
+        if(me->getVictim())
+            return;
+        // if(EventStarted)
+        //     return;
+
+        if (me->canStartAttack(who))
+        {
+            AttackStart(who);
+            who->CombatStart(me);
+            StartEvent();
+            if(pInstance)
+                pInstance->SetData(DATA_AKILZONGAUNTLET, AKILZON_GAUNTLET_IN_PROGRESS);
+        }
     }
 
     void JustDied(Unit* Killer)
@@ -985,19 +998,6 @@ struct npc_amanishi_lookoutAI : public ScriptedAI
 
     void MoveInLineOfSight(Unit *who)
     {
-        if(me->getVictim())
-            return;
-       // if(EventStarted)
-       //     return;
-
-        if (me->canStartAttack(who))
-        {
-            AttackStart(who);
-            who->CombatStart(me);
-            StartEvent();
-            if(pInstance)
-                pInstance->SetData(DATA_AKILZONGAUNTLET, AKILZON_GAUNTLET_IN_PROGRESS);
-        }
     }
 
     void MovementInform(uint32 type, uint32 id)


### PR DESCRIPTION
from MoveInLineOfSight to EnterCombat as MoveInLineOfSight only triggers in Combat, making the Gauntlet Event trigger far too late and make it not behave blizzlike.

With this we can either fix the event start by increasing this npc's aggro range, or using the triggernpc = 24325 with linking to start the event.

At the moment, even if the npc is triggered in combat, the event doesnt start because players need to be in close range (Creature LOS Range).