### PR TITLE
Attempted yet again to fix SSC Consoles

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_fathomlord_karathress.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_fathomlord_karathress.cpp
@@ -230,23 +230,19 @@ struct boss_fathomlord_karathressAI : public ScriptedAI
     {
         DoScriptText(SAY_DEATH, m_creature);
 
-        if(pInstance)
-            pInstance->SetData(DATA_KARATHRESS_EVENT, DONE);
+        pInstance->SetData(DATA_KARATHRESS_EVENT, SPECIAL);
 
         //support for quest 10944
         m_creature->SummonCreature(SEER_OLUM, OLUM_X, OLUM_Y, OLUM_Z, OLUM_O, TEMPSUMMON_TIMED_DESPAWN, 3600000);
 
-
-        //We're going to assume pInstance is null - SO DO NOT ACCESS IT.
-        Map *map = m_creature->GetMap();
-
-        //NOTE: We think pInstance is SOMETIMES NULL - therefore this solution DOES NOT USE pInstance.
         if (Map *map = m_creature->GetMap())
         {
-            //Search distance is 999 yards, which is stupid, but it makes sure it will find the object.
             if (GameObject *go = GetClosestGameObjectWithEntry(m_creature, 185117, 999.0f)) 
                 go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         }
+
+        if ((pInstance->GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LURKER_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+            pInstance->SetData(DATA_UNLOCK_VASHJ_DOOR, SPECIAL);
     }
 
     void EnterCombat(Unit *who)

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_hydross_the_unstable.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_hydross_the_unstable.cpp
@@ -203,18 +203,19 @@ struct boss_hydross_the_unstableAI : public ScriptedAI
         else
             DoScriptText(SAY_CLEAN_DEATH, m_creature);
 
-        if (pInstance)
-            pInstance->SetData(DATA_HYDROSS_EVENT, DONE);
+        pInstance->SetData(DATA_HYDROSS_EVENT, SPECIAL);
+
         Summons.DespawnAll();
 
-
-        //NOTE: We think pInstance is SOMETIMES NULL - therefore this solution DOES NOT USE pInstance.
         if (Map *map = m_creature->GetMap())
         {
             //Search distance is 999 yards, which is stupid, but it makes sure it will find the object.
             if (GameObject *go = GetClosestGameObjectWithEntry(m_creature, 185114, 999.0f)) 
                 go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         }
+
+        if ((pInstance->GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LURKER_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+            pInstance->SetData(DATA_UNLOCK_VASHJ_DOOR, SPECIAL);
     }
 
     void UpdateAI(const uint32 diff)

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_leotheras_the_blind.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_leotheras_the_blind.cpp
@@ -389,20 +389,16 @@ struct boss_leotheras_the_blindAI : public ScriptedAI
                 pUnit->DealDamage(pUnit, pUnit->GetHealth(), DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, false);
         }
 
+        pInstance->SetData(DATA_LEOTHERAS_EVENT, SPECIAL);
 
-        if (pInstance)
-            pInstance->SetData(DATA_LEOTHERAS_EVENT, DONE);
-
-        //We're going to assume pInstance is null - SO DO NOT ACCESS IT.
-        Map *map = m_creature->GetMap();
-
-        //NOTE: We think pInstance is SOMETIMES NULL - therefore this solution DOES NOT USE pInstance.
         if (Map *map = m_creature->GetMap())
         {
-            //Search distance is 999 yards, which is stupid, but it makes sure it will find the object.
             if (GameObject *go = GetClosestGameObjectWithEntry(m_creature, 185116, 999.0f)) 
                 go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         }
+
+        if ((pInstance->GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LURKER_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+            pInstance->SetData(DATA_UNLOCK_VASHJ_DOOR, SPECIAL);
     }
 
     void EnterCombat(Unit *who)

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lurker_below.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lurker_below.cpp
@@ -273,19 +273,17 @@ struct boss_the_lurker_belowAI : public BossAI
 
     void JustDied(Unit* Killer)
     {
-        instance->SetData(DATA_LURKER_EVENT, DONE);
+        instance->SetData(DATA_LURKER_EVENT, SPECIAL);
         me->RemoveAurasDueToSpell(SPELL_SUBMERGE);
 
-        //We're going to assume pInstance is null - SO DO NOT ACCESS IT.
-        Map *map = m_creature->GetMap();
-
-        //NOTE: We think pInstance is SOMETIMES NULL - therefore this solution DOES NOT USE pInstance.
         if (Map *map = m_creature->GetMap())
         {
-            //Search distance is 999 yards, which is stupid, but it makes sure it will find the object.
             if (GameObject *go = GetClosestGameObjectWithEntry(m_creature, 185115, 999.0f)) 
                 go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         }
+
+        if ((instance->GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (instance->GetData(DATA_LURKER_EVENT) == SPECIAL) && (instance->GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (instance->GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (instance->GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+            instance->SetData(DATA_UNLOCK_VASHJ_DOOR, SPECIAL);
     }
 
     void SummonAdds()

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_morogrim_tidewalker.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_morogrim_tidewalker.cpp
@@ -122,18 +122,18 @@ struct boss_morogrim_tidewalkerAI : public ScriptedAI
     void JustDied(Unit *victim)
     {
         DoScriptText(SAY_DEATH, m_creature);
-        pInstance->SetData(DATA_MOROGRIM_EVENT, DONE);
+        pInstance->SetData(DATA_MOROGRIM_EVENT, SPECIAL);
 
-        //We're going to assume pInstance is null - SO DO NOT ACCESS IT.
-        Map *map = m_creature->GetMap();
-
-        //NOTE: We think pInstance is SOMETIMES NULL - therefore this solution DOES NOT USE pInstance.
         if (Map *map = m_creature->GetMap())
         {
             //Search distance is 999 yards, which is stupid, but it makes sure it will find the object.
             if (GameObject *go = GetClosestGameObjectWithEntry(m_creature, 185118, 999.0f)) 
                 go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
         }
+
+        if ((pInstance->GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LURKER_EVENT) == SPECIAL) && (pInstance->GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (pInstance->GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+            pInstance->SetData(DATA_UNLOCK_VASHJ_DOOR, SPECIAL);
+
     }
 
     void EnterCombat(Unit *who)

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/def_serpent_shrine.h
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/def_serpent_shrine.h
@@ -52,6 +52,7 @@ enum DataTypes
     DATA_SHIELD_GENERATOR_FOUR      = 48,
     DATA_CAN_START_PHASE_3          = 49,
     DATA_WATER                      = 50,
+    DATA_UNLOCK_VASHJ_DOOR          = 51
 };
 
 #endif

--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
@@ -37,79 +37,27 @@ ObjectGuid ConsoleGuids[5];
 ObjectGuid BridgeConsoleGuid;
 
 
-bool UnlockVashjDoor(ScriptedInstance* instance)
-{
-    return (((instance->GetData(DATA_HYDROSS_EVENT) == SPECIAL) && 
-    (instance->GetData(DATA_LURKER_EVENT) == SPECIAL)           && 
-    (instance->GetData(DATA_LEOTHERAS_EVENT) == SPECIAL)        && 
-    (instance->GetData(DATA_KARATHRESS_EVENT) == SPECIAL)       && 
-    (instance->GetData(DATA_MOROGRIM_EVENT) == SPECIAL)));
-}
-
-void UnlockGameObject(Map* map, uint64 GameObjectGUID)
-{
-    if (GameObject *go = map->GetGameObject(GameObjectGUID)) 
-    {
-        go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
-    }
-}
-
 bool GOUse_go_vashj_console_access_panel(Player *player, GameObject* go)
 {
     ScriptedInstance* instance = (ScriptedInstance*) go->GetInstanceData();
 
     if (!instance)
-    {
         return false;
-    }
 
-    bool returnVal = true;
+    if (!go)
+        return false;
 
-    uint64 id = go->GetGUID();
-
-    if (id == ConsoleGuids[0])
+    if (go->GetGUID() == BridgeConsoleGuid) 
     {
-        instance->SetData(DATA_HYDROSS_EVENT, SPECIAL);
-        player->TextEmote("activates console #1 [Hydross the Unstable].");
-    }
-    else if (id == ConsoleGuids[1])
-    {
-        instance->SetData(DATA_LURKER_EVENT, SPECIAL);
-        player->TextEmote("activates console #2 [The Lurker Below].");
-    }
-    else if (id == ConsoleGuids[2])
-    {
-        instance->SetData(DATA_LEOTHERAS_EVENT, SPECIAL);
-        player->TextEmote("activates console #3 [Leotheras the Blind].");
-    }
-    else if (id == ConsoleGuids[3])
-    {
-        instance->SetData(DATA_KARATHRESS_EVENT, SPECIAL);
-        player->TextEmote("activates console #4 [Fathom-Lord Karathress].");
-    }
-    else if (id == ConsoleGuids[4])
-    {
-        instance->SetData(DATA_MOROGRIM_EVENT, SPECIAL);
-        player->TextEmote("activates console #5 [Morogrim Tidewalker].");
-    }
-    else if (id == BridgeConsoleGuid) {
         instance->SetData(DATA_BRIDGE_CONSOLE, DONE);
-        player->TextEmote("activates console #6 [Access to Lady Vashj].");
+        player->TextEmote("opened the door and created the platform to Lady Vashj.");
     }
     else
     {
-        returnVal = false;
+        player->TextEmote("clicked the console.");
     }
 
-    if (UnlockVashjDoor(instance))
-    {
-        UnlockGameObject(instance->instance, BridgeConsoleGuid);
-    }
-
-    return returnVal;
-
-    
-
+    return true;
 }
 
 struct instance_serpentshrine_cavern : public ScriptedInstance
@@ -194,6 +142,14 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
         VashjBridgeOpen = false;
     }
 
+    void UnlockGameObject(uint64 GameObjectGUID)
+    {
+        if (GameObject *go = instance->GetGameObject(GameObjectGUID)) 
+        {
+            go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED);
+        }
+    }
+
     void OnObjectCreate(GameObject *go)
     {
         uint32 data = NOT_STARTED;
@@ -203,36 +159,36 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
                 ConsoleGuids[0] = go->GetGUID();               
                 data = GetData(DATA_HYDROSS_EVENT);
                 if ((data == DONE) || (data == SPECIAL))
-                    UnlockGameObject(instance, ConsoleGuids[0]);
+                    UnlockGameObject(ConsoleGuids[0]);
                 break;
             case 185115: // Serpentshrine Console [The Lurker Below]
                 ConsoleGuids[1] = go->GetGUID();
                 data = GetData(DATA_LURKER_EVENT);
                 if ((data == DONE) || (data == SPECIAL))
-                    UnlockGameObject(instance, ConsoleGuids[1]);
+                    UnlockGameObject(ConsoleGuids[1]);
                 break;
             case 185116: // Serpentshrine Console [Leotheras the Blind]
                 ConsoleGuids[2] = go->GetGUID();
                 data = GetData(DATA_LEOTHERAS_EVENT);
                 if ((data == DONE) || (data == SPECIAL))
-                    UnlockGameObject(instance, ConsoleGuids[2]);
+                    UnlockGameObject(ConsoleGuids[2]);
                 break;
             case 185117: // Serpentshrine Console [Fathom-Lord Karathress]
                 ConsoleGuids[3] = go->GetGUID();
                 data = GetData(DATA_KARATHRESS_EVENT);
                 if ((data == DONE) || (data == SPECIAL))
-                    UnlockGameObject(instance, ConsoleGuids[3]);
+                    UnlockGameObject(ConsoleGuids[3]);
                 break;
             case 185118: // Serpentshrine Console [Morogrim Tidewalker]
                 ConsoleGuids[4] = go->GetGUID();
                 data = GetData(DATA_MOROGRIM_EVENT);
                 if ((data == DONE) || (data == SPECIAL))
-                    UnlockGameObject(instance, ConsoleGuids[4]);
+                    UnlockGameObject(ConsoleGuids[4]);
                 break;
             case 184568: // Lady Vashj Bridge Console
                 BridgeConsoleGuid = go->GetGUID();
-                if (UnlockVashjDoor(this))
-                    UnlockGameObject(instance, BridgeConsoleGuid); 
+                if ((GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (GetData(DATA_LURKER_EVENT) == SPECIAL) && (GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+                    UnlockGameObject(BridgeConsoleGuid); 
                 break;
             case 184203: // Doodad_Coilfang_Raid_Bridge_Part01
                 BridgePartGuids[0] = go->GetGUID();
@@ -362,6 +318,9 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
             case DATA_LURKER_FISHING_EVENT:
                 LurkerFishingEvent = data;
                 break;
+            case DATA_UNLOCK_VASHJ_DOOR:
+                UnlockGameObject(BridgeConsoleGuid); 
+            break;
         }
 
         if (data == DONE || data == SPECIAL)
@@ -600,4 +559,5 @@ void AddSC_instance_serpentshrine_cavern()
     newscript->Name="GOUse_go_vashj_console_access_panel";
     newscript->pGOUse = &GOUse_go_vashj_console_access_panel;
     newscript->RegisterSelf();
+
 }


### PR DESCRIPTION
This time, instead of relying on user input to unlock the vashj door, the door will be unlocked depending on only the boss death (Refer to the if statement added to each boss)

Worst case scenario is that the gameobject script is not attached. Now, the door will at least still unlock, because its not being controlled by the script. Worst case scenario, you CAN STILL get to Vashj, but her platform doesn't raise (you can run across it still - there is an invisible path)

So no guild from now on should need GM intervention.