### PR TITLE
Tranquility (26983, 44208) Target flag fixed

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3785,6 +3785,10 @@ void SpellMgr::LoadSpellCustomAttr()
             case 40179:
                 spellInfo->Targets = TARGET_FLAG_GAMEOBJECT;
                 break;
+            case 26983: //Tranquility targets
+            case 44208: 
+                spellInfo->Targets = TARGET_FLAG_DEST_LOCATION;
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
TARGET_FLAG_DEST_LOCATION was missing for Tranquility spells 26983, 44208.