### PR TITLE
Fixes an issue where Neutral mobs can attack, when logic states they...

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -1741,7 +1741,7 @@ bool Creature::IsWithinSightDist(Unit const* u) const
 bool Creature::canStartAttack(Unit const* who) const
 {
     if (isCivilian()
-        || IsNeutralToAll();
+        || IsNeutralToAll()
         || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PASSIVE)
         || !who->isInAccessiblePlacefor (this)
         || (!CanFly() && GetDistanceZ(who) > CREATURE_Z_ATTACK_RANGE)

--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -1741,6 +1741,7 @@ bool Creature::IsWithinSightDist(Unit const* u) const
 bool Creature::canStartAttack(Unit const* who) const
 {
     if (isCivilian()
+        || IsNeutralToAll();
         || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PASSIVE)
         || !who->isInAccessiblePlacefor (this)
         || (!CanFly() && GetDistanceZ(who) > CREATURE_Z_ATTACK_RANGE)

--- a/src/game/movement/packet_builder.cpp
+++ b/src/game/movement/packet_builder.cpp
@@ -85,29 +85,17 @@ namespace Movement
     {
         uint32 last_idx = spline.getPointCount() - 3;
         const Vector3 * real_path = &spline.getPoint(1);
-        Vector3 destination = real_path[last_idx];
 
-
-        size_t lastIndexPos = data.wpos();
         data << last_idx;
-        data << destination;   // destination
+        data << real_path[last_idx];   // destination
         if (last_idx > 1)
         {
+            Vector3 middle = (real_path[0] + real_path[last_idx]) / 2.f;
             Vector3 offset;
             // first and last points already appended
             for(uint32 i = 1; i < last_idx; ++i)
             {
-                offset = destination - real_path[i];
-
-                 // [-ZERO] The client freezes when it gets a zero offset.
-                 // If the offset would be rounded to zero, skip it.
-                 if (fabs(offset.x) < 0.25 && fabs(offset.y) < 0.25 && fabs(offset.z) < 0.25)
-                 {
-                     last_idx--;
-                     data.put(lastIndexPos, last_idx);
-                     continue;
-                 }
-
+                offset = middle - real_path[i];
                 data.appendPackXYZ(offset.x, offset.y, offset.z);
             }
         }

--- a/src/game/movement/packet_builder.cpp
+++ b/src/game/movement/packet_builder.cpp
@@ -93,12 +93,11 @@ namespace Movement
         data << destination;   // destination
         if (last_idx > 1)
         {
-            Vector3 middle = (real_path[0] + real_path[last_idx]) / 2.f;
             Vector3 offset;
             // first and last points already appended
             for(uint32 i = 1; i < last_idx; ++i)
             {
-                offset = middle - real_path[i];
+                offset = destination - real_path[i];
 
                  // [-ZERO] The client freezes when it gets a zero offset.
                  // If the offset would be rounded to zero, skip it.
@@ -113,7 +112,6 @@ namespace Movement
             }
         }
     }
-
 
     void WriteCatmullRomPath(const Spline<int32>& spline, ByteBuffer& data)
     {

--- a/src/game/movement/packet_builder.cpp
+++ b/src/game/movement/packet_builder.cpp
@@ -93,11 +93,12 @@ namespace Movement
         data << destination;   // destination
         if (last_idx > 1)
         {
+            Vector3 middle = (real_path[0] + real_path[last_idx]) / 2.f;
             Vector3 offset;
             // first and last points already appended
             for(uint32 i = 1; i < last_idx; ++i)
             {
-                offset = destination - real_path[i];
+                offset = middle - real_path[i];
 
                  // [-ZERO] The client freezes when it gets a zero offset.
                  // If the offset would be rounded to zero, skip it.
@@ -112,6 +113,7 @@ namespace Movement
             }
         }
     }
+
 
     void WriteCatmullRomPath(const Spline<int32>& spline, ByteBuffer& data)
     {

--- a/src/game/movement/packet_builder.cpp
+++ b/src/game/movement/packet_builder.cpp
@@ -85,17 +85,29 @@ namespace Movement
     {
         uint32 last_idx = spline.getPointCount() - 3;
         const Vector3 * real_path = &spline.getPoint(1);
+        Vector3 destination = real_path[last_idx];
 
+
+        size_t lastIndexPos = data.wpos();
         data << last_idx;
-        data << real_path[last_idx];   // destination
+        data << destination;   // destination
         if (last_idx > 1)
         {
-            Vector3 middle = (real_path[0] + real_path[last_idx]) / 2.f;
             Vector3 offset;
             // first and last points already appended
             for(uint32 i = 1; i < last_idx; ++i)
             {
-                offset = middle - real_path[i];
+                offset = destination - real_path[i];
+
+                 // [-ZERO] The client freezes when it gets a zero offset.
+                 // If the offset would be rounded to zero, skip it.
+                 if (fabs(offset.x) < 0.25 && fabs(offset.y) < 0.25 && fabs(offset.z) < 0.25)
+                 {
+                     last_idx--;
+                     data.put(lastIndexPos, last_idx);
+                     continue;
+                 }
+
                 data.appendPackXYZ(offset.x, offset.y, offset.z);
             }
         }


### PR DESCRIPTION
…shouldn't be able to initiate attack. Consider Atummen The Huntsman in Karazhan.

Reproduce: BEFORE FIX:
Go to Attumen in Kara.
Stand 25 yards away. Right click him (Raise your weapon, i.e. ready to attack)
Continue to walk forward
He will attack YOU, when you are CLEARLY out of melee range. You are still 20 yards away yet he (a neutral NPC) will attack you.

AFTER FIX:
Do as above,
He will NEVER attack first, so right click, and keep moving forward. Only AFTER you melee hit, will he aggro.