### PR TITLE
login queue fix

### DIFF
--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -418,15 +418,7 @@ bool World::RemoveQueuedPlayer(WorldSession* sess)
     // iter point to first not updated socket, position store new position
     for (; iter != m_QueuedPlayer.end(); ++iter, ++position)
         (*iter)->SendAuthWaitQue(position);
-
-    if (!found && getConfig(CONFIG_INTERVAL_DISCONNECT_TOLERANCE))
-    {
-        std::pair<uint32, time_t> tPair;
-        tPair.first = sess->GetAccountId();
-        tPair.second = time(NULL);
-
-        addDisconnectTime(tPair);
-    }
+    
     return found;
 }
 


### PR DESCRIPTION
This was added with the intention of fixing the Disconnect Tolerance time (the time in which you can login again, without queue, after being disconnected).

This commit caused, that players that login without a queue, if there currently is a queue in place, kick another player on login.