### PR TITLE
Fix rogue distract on patrolling mobs + Add missing Unit States

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -4303,20 +4303,23 @@ void Spell::EffectPull(uint32 /*i*/)
 
 void Spell::EffectDistract(uint32 /*i*/)
 {
-    // Check for possible target
+        // Check for possible target
     if (!unitTarget || unitTarget->isInCombat())
         return;
 
     // target must be OK to do this
-    if (unitTarget->hasUnitState(UNIT_STAT_CONFUSED | UNIT_STAT_STUNNED | UNIT_STAT_FLEEING))
+    if (unitTarget->hasUnitState(UNIT_STAT_CAN_NOT_REACT))
         return;
 
-    unitTarget->SetFacingTo(unitTarget->GetAngle(m_targets.m_destX, m_targets.m_destY));
-
-    unitTarget->SetStandState(PLAYER_STATE_NONE);
+    unitTarget->clearUnitState(UNIT_STAT_MOVING);
 
     if (unitTarget->GetTypeId() == TYPEID_UNIT)
         unitTarget->GetMotionMaster()->MoveDistract(damage * IN_MILISECONDS);
+
+    float orientation = unitTarget->GetAngle(m_targets.m_destX, m_targets.m_destY);
+    unitTarget->SetFacingTo(orientation);
+    // This is needed to change the facing server side as well (and it must be after the MoveDistract call)
+    unitTarget->SetOrientation(orientation);
 }
 
 void Spell::EffectPickPocket(uint32 /*i*/)

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -396,12 +396,18 @@ enum UnitState
     UNIT_STAT_CASTING            = 0x00008000,        // unit is casting a spell with cast time
     UNIT_STAT_POSSESSED          = 0x00010000,        // unit is possessed
     UNIT_STAT_CHARGING           = 0x00020000,        // unit is charging
-    //UNIT_STAT_UNUSED           = 0x00040000,
-    //UNIT_STAT_UNUSED           = 0x00100000,
+    UNIT_STAT_JUMPING            = 0x00040000,
+    UNIT_STAT_MOVE               = 0x00100000,
     UNIT_STAT_ROTATING           = 0x00200000,        // unit is rotating
     UNIT_STAT_CASTING_NOT_MOVE   = 0x00400000,        // unit is casting a spell and can NOT move
-    UNIT_STAT_IGNORE_PATHFINDING = 0x00800000,        // unit won't generate path
+    UNIT_STAT_ROAMING_MOVE       = 0x00800000,
+    UNIT_STAT_CONFUSED_MOVE      = 0x01000000,
+    UNIT_STAT_FLEEING_MOVE       = 0x02000000,
+    UNIT_STAT_CHASE_MOVE         = 0x04000000,
+    UNIT_STAT_FOLLOW_MOVE        = 0x08000000,
+    UNIT_STAT_IGNORE_PATHFINDING = 0x10000000,        // unit won't generate path   
 
+    UNIT_STAT_MOVING            = (UNIT_STAT_ROAMING_MOVE | UNIT_STAT_CONFUSED_MOVE | UNIT_STAT_FLEEING_MOVE | UNIT_STAT_CHASE_MOVE | UNIT_STAT_FOLLOW_MOVE),
     UNIT_STAT_CAN_NOT_MOVE      = (UNIT_STAT_ROOT | UNIT_STAT_STUNNED | UNIT_STAT_DIED),
     UNIT_STAT_LOST_CONTROL      = (UNIT_STAT_CONFUSED | UNIT_STAT_STUNNED | UNIT_STAT_FLEEING | UNIT_STAT_CHARGING),
     UNIT_STAT_SIGHTLESS         = (UNIT_STAT_LOST_CONTROL),


### PR DESCRIPTION
*Update Unit States to better match what trinity has: https://github.com/trinityclassic/trinityone/blob/369ad702109b70183570fecf23c73afe2cbeb3fc/src/server/game/Entities/Unit/Unit.h#L485

*Distract now turns units that are moving on a path:
https://github.com/cmangos/mangos-tbc/commit/d23d2f805acbd2073507f473f37e8938d18cb575

*Solves: https://github.com/Looking4Group/L4G_Core/issues/2739