### PR TITLE
Custom spell delay system

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -56,6 +56,108 @@
 
 extern pEffect SpellEffects[TOTAL_SPELL_EFFECTS];
 
+// Custom Spell Delay
+uint64 GetCustomSpellDelay(SpellEntry const *spellInfo)
+{
+    // Warrior ---------------------------------------------------------------
+    // Sword Specialisation Proc
+    if (spellInfo->SpellIconID == 1462 && spellInfo->SpellVisual == 6560 && spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR)
+        return 500;
+    // Charge Stun
+    if (spellInfo->SpellFamilyFlags & 0x1000000 && spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR)
+        return 200;
+    // Intercept Stun, Mace Stun Effect (Improved Concussive Shot - Hunter)
+    if (spellInfo->SpellVisual == 2816 && spellInfo->SpellIconID == 15)
+        return 200;
+
+    // Paladin ---------------------------------------------------------------
+    // Hammer of Justice
+    if (spellInfo->SpellVisual == 322 && spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN)
+        return 200;
+    // Seal of Command Proc Attack
+    if (spellInfo->Id == 20424)
+        return 500;
+    // Seal of Blood Judgement
+    if (spellInfo->Id == 32220)
+        return 1000;
+    // Repentance
+    if (spellInfo->Id == 20066)
+        return 200;
+    // Seal of Blood Proc
+    if (spellInfo->Id == 31893)
+        return 500;
+    // Illumination Proc
+    if (spellInfo->Id == 20272)
+        return 100;
+
+    // Shaman ----------------------------------------------------------------
+    // Windfury
+    if (spellInfo->SpellIconID == 220 && spellInfo->SpellFamilyName == SPELLFAMILY_SHAMAN)
+        return 500;
+    // Windfury totem effect
+    if (spellInfo->SpellIconID == 8251 && spellInfo->SpellVisual == 1397 && spellInfo->SpellFamilyName == SPELLFAMILY_SHAMAN)
+        return 500;
+
+    // Druids -----------------------------------------------------------------
+    // Pounce
+    if (spellInfo->SpellIconID == 495 && spellInfo->SpellFamilyName == SPELLFAMILY_DRUID)
+        return 200;
+
+    // Rogues ------------------------------------------------------------------
+    // Gouge
+    if (spellInfo->SpellVisual == 256 && spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE)
+        return 200;
+    // Blind
+    if (spellInfo->SpellIconID == 48 && spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE)
+        return 200;
+    // Sap
+    if (spellInfo->SpellIconID == 249 && spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE)
+        return 200;
+    // Cheap Shot
+    if (spellInfo->SpellIconID == 244 && spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE)
+        return 200;
+    // Ruthlessness
+    if (spellInfo->Id == 14157)
+        return 100;
+    // Seal Fate
+    if (spellInfo->Id == 14189)
+        return 100;
+
+    // Mage --------------------------------------------------------------------
+    // Polymorph
+    if (spellInfo->SpellFamilyFlags & 0x1000000LL && spellInfo->SpellFamilyName == SPELLFAMILY_MAGE)
+        return 200;
+
+    // Warlock -----------------------------------------------------------------
+    // Shadowfury
+    if (spellInfo->SpellFamilyFlags & 0x0000100000000000LL && spellInfo->SpellFamilyName == SPELLFAMILY_WARLOCK)
+        return 200;
+
+    // Misc.
+    switch(spellInfo->Id)
+    {
+        case 31616: // Nature's Guardian
+        case 17794: // Shadow Vulnerability (Rank 1)
+        case 17797: // Shadow Vulnerability (Rank 2)
+        case 17798: // Shadow Vulnerability (Rank 3)
+        case 17799: // Shadow Vulnerability (Rank 4)
+        case 17800: // Shadow Vulnerability (Rank 5)
+        case 12966: // Flury (Rank 1)
+        case 12967: // Flury (Rank 2)
+        case 12968: // Flury (Rank 3)
+        case 12969: // Flury (Rank 4)
+        case 12970: // Flury (Rank 5)
+        case 33076: // Prayer of Mending
+        case 32848: // Mana Restore (From Insightful Earthstorm Diamond)
+            return 100;
+        case 14181: // Relentless Strikes Effect
+            return 500;
+            break;
+    }
+    // Default - Return none
+    return 0;
+}
+
 bool IsQuestTameSpell(uint32 spellId)
 {
     SpellEntry const *spellproto = sSpellStore.LookupEntry(spellId);
@@ -786,6 +888,9 @@ void Spell::AddUnitTarget(Unit* pVictim, uint32 effIndex, bool redirected)
     }
     else
         target.timeDelay = 0LL;
+
+    // Calculate Additional Custom PvP spell delays
+    m_delayMoment = GetCustomSpellDelay(m_spellInfo) ? GetCustomSpellDelay(m_spellInfo) : target.timeDelay;
 
     // If target reflect spell back to caster
     if (target.missCondition == SPELL_MISS_REFLECT)

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -443,7 +443,7 @@ class Spell
         }
         bool IsDelayedSpell() const
         {
-            return GetSpellInfo()->speed > 0.0f || GetSpellInfo()->AttributesCu & SPELL_ATTR_CU_FAKE_DELAY;
+            return m_delayMoment || GetSpellInfo()->speed > 0.0f || GetSpellInfo()->AttributesCu & SPELL_ATTR_CU_FAKE_DELAY;
         }
         bool IsChannelActive() const { return m_caster->GetUInt32Value(UNIT_CHANNEL_SPELL) != 0; }
         bool IsMeleeAttackResetSpell() const { return !m_IsTriggeredSpell && (GetSpellInfo()->InterruptFlags & SPELL_INTERRUPT_FLAG_AUTOATTACK);  }

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3089,9 +3089,6 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->AttributesCu |= SPELL_ATTR_CU_NO_SCROLL_STACK;
                 break;
             /* ROGUE CUSTOM ATTRIBUTES */
-            case 2094:                     // Blind
-                spellInfo->AttributesCu |= SPELL_ATTR_CU_FAKE_DELAY; // add const fake delay
-                break;
             case 5171:
             case 6774:                     // Slice'n'Dice
         spellInfo->AttributesEx3 |= SPELL_ATTR_EX3_NO_INITIAL_AGGRO;
@@ -3117,18 +3114,6 @@ void SpellMgr::LoadSpellCustomAttr()
         case 15290: // Vampiric Embrace (Healing)
         spellInfo->AttributesEx3 |= SPELL_ATTR_EX3_NO_INITIAL_AGGRO; // Do not put caster in combat after use
         break;
-            // Triggered spells that should be delayed
-            case 32848:                     // Mana Restore
-            case 14189:                     // Seal Fate
-            case 14157:                     // Ruthlessness
-            case 14181:                     // Relentless Strikes
-            case 17794:                     // Improved Shadow Bolt ranks 1-5
-            case 17797:
-            case 17798:
-            case 17799:
-            case 17800:
-                spellInfo->AttributesCu |= SPELL_ATTR_CU_FAKE_DELAY;
-                break;
             /* UNSORTED */
             /* Damage Corrections */
             case 33627: // Rain of Fire (Pit Commander)
@@ -3644,7 +3629,6 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->RecoveryTime = 120000;
                 break;
             case 20272: //Illumination
-                spellInfo->AttributesCu |= SPELL_ATTR_CU_FAKE_DELAY;
                 spellInfo->Attributes |= SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY;
                 break;
             case 19588: //Place ghost magnet


### PR DESCRIPTION
AttributeCu SPELL_ATTR_CU_FAKE_DELAY seemed really useless to me, since it's not customizable at all and will always be a delay of 200ms, unless I really don't understand the old system.
Instead I ported the custom spell delay system from tbcpvp. All credit goes to them.

This system makes it possible to Seal Twist (https://github.com/Looking4Group/L4G_Core/issues/2166) and do things like breaking your own poly with SW:D (https://github.com/Looking4Group/L4G_Core/issues/2200).

https://bitbucket.org/Xadras/tbcpvp/commits/18f287efe616850c1f435fe232eed3959b8ada10
https://bitbucket.org/Xadras/tbcpvp/commits/1a27f8fd23cad12b30b7c8ca854acabf1db9d7a4

Tested locally.