### PR TITLE
DLK Cross-Faction Heal Fix

### DIFF
--- a/src/scripts/scripts/zone/hellfire_peninsula/boss_doomlord_kazzak.cpp
+++ b/src/scripts/scripts/zone/hellfire_peninsula/boss_doomlord_kazzak.cpp
@@ -116,7 +116,7 @@ struct boss_doomlordkazzakAI : public BossAI
 
     void KilledUnit(Unit* pVictim)
     {
-        if (pVictim->GetTypeId() == TYPEID_PLAYER)
+        if ((pVictim->GetTypeId() == TYPEID_PLAYER) && (pVictim->getFaction() == me->GetLootRecipient()->getFaction()))
         {
             if (!HealthBelowPct(1))
             {


### PR DESCRIPTION
Only kills of the **same** faction that engaged Doom Lord Kazzak should heal him.
Source: http://wowwiki.wikia.com/wiki/Doom_Lord_Kazzak_(tactics)?oldid=1489683

This still allows for opposite factions to contest Kazzak by killing the other faction, rather than suiciding to Kazzak and healing him for 150,000, relying on the enrage timer to wipe them.