### PR TITLE
There was an issue with Windows Compilation. 

### DIFF
--- a/win/VC100/TrinityScripts.vcxproj
+++ b/win/VC100/TrinityScripts.vcxproj
@@ -473,6 +473,8 @@
     <ClCompile Include="..\..\src\scripts\scripts\creature\simple_ai.cpp" />
     <ClCompile Include="..\..\src\scripts\scripts\custom\barber.cpp" />
     <ClCompile Include="..\..\src\scripts\scripts\custom\boss_easter_event.cpp" />
+    <ClCompile Include="..\..\src\scripts\scripts\custom\custom_instant_70.cpp" />
+    <ClCompile Include="..\..\src\scripts\scripts\custom\custom_transfer.cpp" />
     <ClCompile Include="..\..\src\scripts\scripts\custom\enchant_npc.cpp" />
     <ClCompile Include="..\..\src\scripts\scripts\custom\lootbox.cpp" />
     <ClCompile Include="..\..\src\scripts\scripts\guard\guard_ai.cpp" />

--- a/win/VC100/TrinityScripts.vcxproj.filters
+++ b/win/VC100/TrinityScripts.vcxproj.filters
@@ -1573,6 +1573,12 @@
     <ClCompile Include="..\..\src\scripts\scripts\zone\redridge_mountains\redridge_mountains.cpp">
       <Filter>Scripts\zone\Redridge Mountains</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\scripts\scripts\custom\custom_instant_70.cpp">
+      <Filter>Scripts\custom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\scripts\scripts\custom\custom_transfer.cpp">
+      <Filter>Scripts\custom</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\scripts\scripts\creature\simple_ai.h">


### PR DESCRIPTION
The reason is that there were unresolved externals. This is a result of adding the custom scripts for the character transfers and 70 event - while they were added to the linux build tools, they were not added to the vcxproj required by Visual Studio, therefore it doesn't know about them. This commit fixes that.