### PR TITLE
Core/Quest: Fix repeatable quest crash

### DIFF
--- a/src/game/QuestHandler.cpp
+++ b/src/game/QuestHandler.cpp
@@ -636,8 +636,13 @@ uint32 WorldSession::getDialogStatus(Player *pPlayer, Object* questgiver, uint32
             {
                 if (pPlayer->SatisfyQuestLevel(pQuest, false))
                 {
-                    if (pQuest->IsAutoComplete() || (pQuest->IsRepeatable() && pPlayer->getQuestStatusMap()[quest_id].m_rewarded))
+                    auto questStatusItr = pPlayer->getQuestStatusMap().find(quest_id);
+                    bool rewarded = (questStatusItr != pPlayer->getQuestStatusMap().end()) ? questStatusItr->second.m_rewarded : false;
+
+                    if (pQuest->IsAutoComplete() || (pQuest->IsRepeatable() && rewarded))
+                    {
                         result2 = DIALOG_STATUS_REWARD_REP;
+                    }
                     else if (pPlayer->ShowLowLevelQuest() || (pPlayer->getLevel() <= pPlayer->GetQuestOrPlayerLevel(pQuest) + sWorld.getConfig(CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF)))
                     {
                         if (pQuest->HasFlag(QUEST_FLAGS_DAILY))


### PR DESCRIPTION
Like in Dagger Hills but probably in others places
Badly assumed that quest always exist in map.

Credits to OregonCore
(https://github.com/OregonCore/OregonCore/commit/1ffcba90bf882d9ca654314400f1b67c0f20b3f1)
and mangos-tbc
(https://github.com/cmangos/mangos-tbc/commit/75b0d0a4e2f01ee5b7031ab40bdeed0d32b7ddcf)