### PR TITLE
Core/Logout: Remove UNIT_FLAG2_FEIGN_DEATH after logout

### DIFF
--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -557,6 +557,7 @@ void WorldSession::LogoutPlayer(bool Save)
             {
                  _player->RemoveSpellsCausingAura(SPELL_AURA_MOD_UNATTACKABLE);
                  _player->RemoveCharmAuras();
+                 _player->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
             }
         }
 

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -553,15 +553,15 @@ void WorldSession::LogoutPlayer(bool Save)
                 _player->BuildPlayerRepop();
                 _player->RepopAtGraveyard();
             }
-            else if (_player->HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH))
-            {
-                // this will fix permanent death state bug after relog
-                 _player->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
-            }
             else
             {
-                 _player->RemoveSpellsCausingAura(SPELL_AURA_MOD_UNATTACKABLE);
-                 _player->RemoveCharmAuras();
+                _player->RemoveSpellsCausingAura(SPELL_AURA_MOD_UNATTACKABLE);
+                _player->RemoveCharmAuras();
+            }
+            if (_player->HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH)) 
+            {
+                // this will fix permanent death state bug after relog
+                _player->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
             }
         }
 

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -553,11 +553,15 @@ void WorldSession::LogoutPlayer(bool Save)
                 _player->BuildPlayerRepop();
                 _player->RepopAtGraveyard();
             }
+            else if (_player->HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH))
+            {
+                // this will fix permanent death state bug after relog
+                 _player->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
+            }
             else
             {
                  _player->RemoveSpellsCausingAura(SPELL_AURA_MOD_UNATTACKABLE);
                  _player->RemoveCharmAuras();
-                 _player->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
             }
         }
 

--- a/src/scripts/scripts/zone/shadowmoon_valley/shadowmoon_valley.cpp
+++ b/src/scripts/scripts/zone/shadowmoon_valley/shadowmoon_valley.cpp
@@ -1938,7 +1938,7 @@ static float SuccubPos2[4] = {-3730.46,1041.40,55.95,4.60};
 
 // BT prelude after quest 10944 creatures & spells & emotes
 #define ILLIDAN                     22083
-#define    SEER_OLUM                   22820
+#define SEER_OLUM                   22820
 #define OLUMS_SPIRIT                22870
 #define SPELL_OLUMS_SACRIFICE       39552
 #define STATE_DROWNED                 383


### PR DESCRIPTION
this solves 
https://github.com/Looking4Group/L4G_Core/issues/3107

not affecting feign death - you still got the aura SPELL_AURA_FEIGN_DEATH after relog

(1. cast 5384 while in combat
2. relog beside a NPC
3. still got the aura and wont get in combat)

+ small typo fix