### PR TITLE
Core/Blood Furnace - Add evade range to summoners

### DIFF
--- a/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_kelidan_the_breaker.cpp
+++ b/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_kelidan_the_breaker.cpp
@@ -374,7 +374,7 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
         {
             if (check_Timer < diff)
             {
-                if (!m_creature->IsWithinDistInMap(&kelidanWorldLoc, 120.0f)) // If they die too far away from Kelidan he will be forever non-attackable. Search range is 100. 120 is safe because there's about 20y between the summoners and the boss's home locations and only one summoner needs to be in range on death.
+                if (!m_creature->IsWithinDistInMap(&kelidanWorldLoc, 120.0f)) // If they die too far away from Kelidan he will be forever non-attackable. 
                 {
                     EnterEvadeMode();
                 }

--- a/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_kelidan_the_breaker.cpp
+++ b/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_kelidan_the_breaker.cpp
@@ -300,6 +300,11 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
     mob_shadowmoon_channelerAI(Creature *c) : ScriptedAI(c)
     {
         pInstance = (c->GetInstanceData());
+
+        if (Creature *Kelidan = (Creature *)FindCreature(ENTRY_KELIDAN, 30, m_creature))
+            ((boss_kelidan_the_breakerAI*)Kelidan->AI())->m_creature->GetPosition(kelidanWorldLoc);
+
+        m_creature->GetPosition(wLoc);
     }
 
     ScriptedInstance* pInstance;
@@ -307,6 +312,9 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
     uint32 ShadowBolt_Timer;
     uint32 MarkOfShadow_Timer;
     uint32 check_Timer;
+
+    WorldLocation kelidanWorldLoc;
+    WorldLocation wLoc;
 
     void Reset()
     {
@@ -330,7 +338,7 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
 
     void JustDied(Unit* Killer)
     {
-       if(Creature *Kelidan = (Creature *)FindCreature(ENTRY_KELIDAN, 100, m_creature))
+       if(Creature *Kelidan = (Creature *)FindCreature(ENTRY_KELIDAN, 125, m_creature))
            ((boss_kelidan_the_breakerAI*)Kelidan->AI())->ChannelerDied(Killer);
     }
 
@@ -338,21 +346,43 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
     {
         if (!UpdateVictim())
         {
-            if(check_Timer < diff)
+            if (check_Timer < diff)
             {
-                if (!m_creature->IsNonMeleeSpellCasted(false))
-                    if(Creature *Kelidan = (Creature *)FindCreature(ENTRY_KELIDAN, 100, m_creature))
+                if (!m_creature->IsWithinDistInMap(&wLoc, 0.5f))
+                {
+                    EnterEvadeMode();
+                }
+                else if (!m_creature->IsNonMeleeSpellCasted(false)) // Don't start channeling until reaching home position
+                {
+                    if (Creature *Kelidan = (Creature *)FindCreature(ENTRY_KELIDAN, 30, m_creature))
                     {
                         uint64 channeler = ((boss_kelidan_the_breakerAI*)Kelidan->AI())->GetChanneled(m_creature);
-                        if(Unit *channeled = Unit::GetUnit(*m_creature, channeler))
-                            DoCast(channeled,SPELL_CHANNELING);
+                        if (Unit *channeled = Unit::GetUnit(*m_creature, channeler))
+                            DoCast(channeled, SPELL_CHANNELING);
                     }
+                }
+
                 check_Timer = 5000;
             }
             else
                 check_Timer -= diff;
 
             return;
+        }
+
+        if (UpdateVictim())
+        {
+            if (check_Timer < diff)
+            {
+                if (!m_creature->IsWithinDistInMap(&kelidanWorldLoc, 120.0f)) // If they die too far away from Kelidan he will be forever non-attackable. Search range is 100. 120 is safe because there's about 20y between the summoners and the boss's home locations and only one summoner needs to be in range on death.
+                {
+                    EnterEvadeMode();
+                }
+
+                check_Timer = 5000;
+            }
+            else
+                check_Timer -= diff;
         }
 
         if (MarkOfShadow_Timer < diff)

--- a/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_kelidan_the_breaker.cpp
+++ b/src/scripts/scripts/zone/hellfire_citadel/blood_furnace/boss_kelidan_the_breaker.cpp
@@ -304,7 +304,7 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
         if (Creature *Kelidan = (Creature *)FindCreature(ENTRY_KELIDAN, 30, m_creature))
             ((boss_kelidan_the_breakerAI*)Kelidan->AI())->m_creature->GetPosition(kelidanWorldLoc);
 
-        m_creature->GetPosition(wLoc);
+        m_creature->GetPosition(summonerWorldLoc);
     }
 
     ScriptedInstance* pInstance;
@@ -314,7 +314,7 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
     uint32 check_Timer;
 
     WorldLocation kelidanWorldLoc;
-    WorldLocation wLoc;
+    WorldLocation summonerWorldLoc;
 
     void Reset()
     {
@@ -348,7 +348,7 @@ struct mob_shadowmoon_channelerAI : public ScriptedAI
         {
             if (check_Timer < diff)
             {
-                if (!m_creature->IsWithinDistInMap(&wLoc, 0.5f))
+                if (!m_creature->IsWithinDistInMap(&summonerWorldLoc, 0.5f))
                 {
                     EnterEvadeMode();
                 }


### PR DESCRIPTION
- The Summoners in Keli'dan's room needs to evade when they are outside of the death search radius. (https://github.com/Looking4Group/L4G_Core/issues/3076)

Otherwise if the party kills the summoners really far away, Keli'dan will be forever in non-attackable mode and the summoners won't respawn, which means a GM has to help.
Their evade range is far enough that you can still pull them to the ramp down.

- Also fixed the issue where the Summoners wouldn't run back to their home point when going out of combat. This in turn seems to have solved a third issue where Keli'dan would release instantly sometimes when being pulled. I can no longer reproduce that issue after these fixes. (https://github.com/Looking4Group/L4G_Core/issues/1028)