### PR TITLE
Core/Mag'theridon - Fix the reset issue in phase 1

### DIFF
--- a/src/scripts/scripts/zone/hellfire_citadel/magtheridons_lair/instance_magtheridons_lair.cpp
+++ b/src/scripts/scripts/zone/hellfire_citadel/magtheridons_lair/instance_magtheridons_lair.cpp
@@ -147,6 +147,7 @@ struct instance_magtheridons_lair : public ScriptedInstance
                         break;
                     case NOT_STARTED:
                         RespawnTimer = 10000;
+                        CageTimer = 0;
                     default:
                         HandleGameObject(DoorGUID, true);
                         break;


### PR DESCRIPTION
Fix the issue where Mag'theridon's cage timer wouldn't reset if you wiped in phase 1, causing him to release even if the raid is not in combat.

Solves https://github.com/Looking4Group/L4G_Core/issues/2797 and https://github.com/Looking4Group/L4G_Core/issues/2340