### PR TITLE
Update mob_fel_stalkerAI

### DIFF
--- a/src/scripts/scripts/zone/caverns_of_time/hyjal/hyjal_trash.cpp
+++ b/src/scripts/scripts/zone/caverns_of_time/hyjal/hyjal_trash.cpp
@@ -1210,7 +1210,7 @@ struct mob_fel_stalkerAI : public hyjal_trashAI
 
     void Reset()
     {
-        ManaBurnTimer = 9000+rand()%5000;
+        ManaBurnTimer = urand(3000, 9000);
     }
 
     void WaypointReached(uint32 i)
@@ -1287,9 +1287,16 @@ struct mob_fel_stalkerAI : public hyjal_trashAI
             return;
         if(ManaBurnTimer<diff)
         {
-            DoCast(m_creature->getVictim(),SPELL_MANA_BURN);
-            ManaBurnTimer = 9000+rand()%5000;
-        }else ManaBurnTimer -= diff;
+            if(Unit *target = SelectUnit(SELECT_TARGET_RANDOM, 0, GetSpellMaxRange(SPELL_MANA_BURN), true, POWER_MANA))
+                DoCast(target, SPELL_MANA_BURN);
+            else
+                DoCast(m_creature->getVictim(), SPELL_MANA_BURN);
+                
+            ManaBurnTimer = urand(6000, 9000);
+        }
+        else
+            ManaBurnTimer -= diff;
+        
         DoMeleeAttackIfReady();
     }
 };


### PR DESCRIPTION
-- Fel Stalker
('1791601','17916','9','0','100','3','0','30','6000','9000','11','31729','5','0','0','0','0','0','0','0','0','0','Fel Stalker - Cast Mana Burn'),

http://www.wowhead.com/npc=17916/fel-stalker#comments
By Yakra (1,653 – 1·3·28) on 2008/07/04 (Patch 2.4.2)		
[Tanks / Raid Leaders] : Their mana burn randomly selects a mana user in range - tanks cannot out threat it.
It is interuptable, they are stunable, ect.
It is not advisable to have a paladin tank these. Luckily, every wave that has them has a number of other targets for a paladin to tank (infernals, ect).