### PR TITLE
ZA Fix/Cleanup

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3852,6 +3852,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 break;
             case 43622: // Static Disruption
                 spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_MOVEMENT;
+                break;
             default:
                 break;
         }

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3231,8 +3231,6 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->InterruptFlags &= ~SPELL_INTERRUPT_FLAG_MOVEMENT;
             case 26029: // Dark Glare
             case 43213: // Flame Whirl
-            case 43648: // Electrical Storm
-            case 43622: // Static Disruption
             case 43140: 
             case 43215: // Flame Breath
                 spellInfo->ChannelInterruptFlags |= CHANNEL_INTERRUPT_FLAG_MOVEMENT;
@@ -3846,7 +3844,14 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->Targets = TARGET_FLAG_DEST_LOCATION;
                 spellInfo->EffectRadiusIndex[0] = 18;
                 spellInfo->EffectRadiusIndex[1] = 18;
-                break;   
+                break;
+            case 43648: // Electrical Storm
+                spellInfo->ChannelInterruptFlags |= CHANNEL_INTERRUPT_FLAG_MOVEMENT;
+                spellInfo->Attributes |= SPELL_ATTR_EX4_DAMAGE_DOESNT_BREAK_AURAS;
+                spellInfo->InterruptFlags = 0x23;
+                break;
+            case 43622: // Static Disruption
+                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_MOVEMENT;
             default:
                 break;
         }

--- a/src/scripts/scripts/zone/zulaman/instance_zulaman.cpp
+++ b/src/scripts/scripts/zone/zulaman/instance_zulaman.cpp
@@ -455,6 +455,9 @@ struct instance_zulaman : public ScriptedInstance
                 else if (data == NOT_STARTED)
                     HandleGameObject(ZulJinDoorGUID, true);
             }
+            else if (Encounters[6] == DONE)
+                if (data == DONE)
+                    HandleGameObject(ZulJinDoorGUID, true);
             break;
         case DATA_CHESTLOOTED:
             ChestLooted++;


### PR DESCRIPTION
Zul'jin now needs fnish fight check to open door on death.
Electric Storm still suffers from random cancel, tryed to mitigate that.
Static disruption is casted spell not channeled spell needs another moveinterrupt flag.