### PR TITLE
Shade of Aran

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3525,6 +3525,12 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->EffectImplicitTargetA[1] = TARGET_UNIT_CASTER;
                 spellInfo->EffectImplicitTargetA[2] = TARGET_UNIT_TARGET_ENEMY;
                 break;
+            case 29978: // Aran Pyroblast
+                spellInfo->Attributes &= ~SPELL_ATTR_LEVEL_DAMAGE_CALCULATION;
+                break;
+            case 29946: // Aran Flame Wreath
+                spellInfo->EffectRadiusIndex[0] = EFFECT_RADIUS_2_YARDS;
+                break;
             case 32785: // Infernal Rain                
                 spellInfo->EffectImplicitTargetA[0] = TARGET_UNIT_TARGET_ENEMY;
                 spellInfo->EffectImplicitTargetB[0] = 0;


### PR DESCRIPTION
Introduced Enum
Fixed Flame Wreath matching Circle Radius
Fixed Pyroblast Damage
Implemented Prenerf DragonsBreath
Kill Water Elementals on Death
Exclude Pets & Totems from NormalCasts
Fix Random Movement during Fight and Correct Position for Teleportation
& Stop Movement during Drinking Phase
Tryfix Always Summon Elementals on Threshold

https://github.com/Looking4Group/L4G_Core/pull/3189/commits/d721ded729872c513938c441311465a124d266e8