### PR TITLE
Omor & Spells

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3179,6 +3179,9 @@ void SpellMgr::LoadSpellCustomAttr()
             case 24311: // Powerful Healing Ward
                 spellInfo->CastingTimeIndex = 14;
                 break;
+            case 39297: // Omor the Unscarred Shadowbolt Prenerf?
+                spellInfo->CastingTimeIndex = 5;
+                break;
             case 24178: // Will of Hakkar
                 spellInfo->AttributesEx |= SPELL_ATTR_EX_CHANNELED_1;
                 break;
@@ -3546,6 +3549,10 @@ void SpellMgr::LoadSpellCustomAttr()
             case 30207: // Magtheridon's creatures Shadow Grasp
                 spellInfo->StackAmount = 5;
                 break;
+            case 30641: // Watchkeeper Gargolmar Mortal Wound Prenerf
+            case 36814:
+                spellInfo->StackAmount = 10;
+                break;
             case 20814: // Collect Dire Water
                 spellInfo->InterruptFlags = SPELL_INTERRUPT_FLAG_MOVEMENT | SPELL_INTERRUPT_FLAG_DAMAGE | SPELL_INTERRUPT_FLAG_AUTOATTACK | SPELL_INTERRUPT_FLAG_PUSH_BACK | SPELL_INTERRUPT_FLAG_INTERRUPT;
                 break;
@@ -3742,7 +3749,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->AttributesEx4 |= SPELL_ATTR_EX4_DAMAGE_DOESNT_BREAK_AURAS;
                 break;
             case 43362: // Electrified Net
-                spellInfo->CastingTimeIndex = 0;
+                spellInfo->CastingTimeIndex = 1;
                 break;
             case 8064:
                 spellInfo->Mechanic = MECHANIC_SLEEP;
@@ -3839,7 +3846,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 break;
             case 40080: //Booming Voice
                 spellInfo->EffectRealPointsPerLevel[0] = 0;
-		            break;
+                break;
             case 44008: //Static Disruption
                 spellInfo->Targets = TARGET_FLAG_DEST_LOCATION;
                 spellInfo->EffectRadiusIndex[0] = 18;

--- a/src/scripts/include/sc_creature.cpp
+++ b/src/scripts/include/sc_creature.cpp
@@ -372,9 +372,9 @@ void ScriptedAI::CastNextSpellIfAnyAndReady(uint32 diff)
             if (tempU && tempU->IsInWorld() && tempU->isAlive() && tempU->IsInMap(m_creature))
                 if (temp.spellId)
                 {					
-					Unit* target = m_creature->GetUnit(temp.targetGUID);
-					m_creature->SetInFront(target);
-                    //if(temp.setAsTarget && !m_creature->hasIgnoreVictimSelection())
+					//Unit* target = m_creature->GetUnit(temp.targetGUID);
+					//m_creature->SetInFront(target);
+                    if(temp.setAsTarget && !m_creature->hasIgnoreVictimSelection())
                         m_creature->SetSelection(temp.targetGUID);
                     if(temp.hasCustomValues)
                         m_creature->CastCustomSpell(tempU, temp.spellId, &temp.damage[0], &temp.damage[1], &temp.damage[2], temp.triggered);


### PR DESCRIPTION
Introduced enum
Fixed Aggro Range
Fixed Timer Overlapping(mostly)
Fixed Shadowwhip / FalltoDeath yolo
Fixed OrbitalStrike Falldamage
Fixed some Selection/Facing Issues
Excluded Pet of Spelltargets

Fixed Creature Selftargeting on Spellcast(which is aoe)
Gargolmar Mortal Wound Prenerf
Typos

https://github.com/Looking4Group/L4G_Core/pull/3189/commits/64230380ef54a3d0a3dc2202d6ffb827f87c046c