### PR TITLE
Login queue now limits each faction to half the population limit

### DIFF
--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -159,6 +159,36 @@ char const* WorldSession::GetPlayerName() const
     return GetPlayer() ? GetPlayer()->GetName() : "<none>";
 }
 
+uint32 WorldSession::GetAccountTeamId() const
+{
+    QueryResultAutoPtr resultRace = RealmDataDatabase.PQuery("SELECT race FROM characters WHERE account ='%u' LIMIT 1", GetAccountId());
+
+    if (!resultRace)
+    {
+        return TEAM_NEUTRAL;
+    }
+    else
+    {
+        Field *fields = resultRace->Fetch();
+        
+        switch (fields[0].GetUInt8())
+        {
+            case RACE_HUMAN:
+            case RACE_DWARF:
+            case RACE_NIGHTELF:
+            case RACE_GNOME:
+            case RACE_DRAENEI:
+                return TEAM_ALLIANCE;
+            case RACE_ORC:
+            case RACE_UNDEAD_PLAYER:
+            case RACE_TAUREN:
+            case RACE_TROLL:
+            case RACE_BLOODELF:
+                return TEAM_HORDE;
+        }
+    }
+}
+
 void WorldSession::SaveOpcodesDisableFlags()
 {
     static SqlStatementID saveOpcodesDisabled;

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -184,6 +184,7 @@ class LOOKING4GROUP_IMPORT_EXPORT WorldSession
         uint32 GetAccountId() const { return _accountId; }
         Player* GetPlayer() const { return _player; }
         char const* GetPlayerName() const;
+        uint32 GetAccountTeamId() const;
         void SetSecurity(uint64 permissions) { m_permissions = permissions; }
         std::string const& GetRemoteAddress() { return m_Address; }
         void SetPlayer(Player *plr) { _player = plr; }


### PR DESCRIPTION
Scenario: population cap is set to 2,000. At any given time there can only be 1,000 Horde and 1,000 Alliance. If there are 1,000 Horde and only 600 Alliance all Horde will have to wait until a "Horde slot" becomes free. Alliance will not have to queue until their faction takes up all 1,000 "Alliance slots". (and vice versa)

Looking through this there is a fair bit of (apparently) redundant code and/or funky logic but I wanted to leave as much of it as possible in tact when implementing this solution.

Will require testing with multiple people.