### PR TITLE
Core/InstanceSaveMgr: Try to prevent crash on shutdown

### DIFF
--- a/src/game/InstanceSaveMgr.cpp
+++ b/src/game/InstanceSaveMgr.cpp
@@ -71,7 +71,8 @@ void InstanceSaveManager::UnbindBeforeDelete()
         save->m_playerList.clear();
 
         for (InstanceSave::GroupListType::iterator itr2 = save->m_groupList.begin(); itr2 != save->m_groupList.end(); ++itr2)
-            (*itr2)->UnbindInstance(save->GetMapId(), save->GetDifficulty(), true);
+            if ((*itr2) != nullptr) // just to prevent crashes on shutdown - we must find why groups can be nulled before calling this function
+                (*itr2)->UnbindInstance(save->GetMapId(), save->GetDifficulty(), true);
 
         save->m_groupList.clear();
         delete save;


### PR DESCRIPTION
related to crash:

`Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffb6ffd700 (LWP 13957)]
_M_find_node (this=0x7fff6758bbf8, __code=<optimized out>, __k=<synthetic pointer>, __p=0x303932) at /usr/include/c++/4.9/tr1/hashtable.h:830
830		if (this->_M_compare(__k, __code, __p))
#0  _M_find_node (this=0x7fff6758bbf8, __code=<optimized out>, __k=<synthetic pointer>, __p=0x303932) at /usr/include/c++/4.9/tr1/hashtable.h:830
#1  find (this=0x7fff6758bbf8, this=0x7fff6758bbf8, __k=<synthetic pointer>) at /usr/include/c++/4.9/tr1/hashtable.h:698
#2  Group::UnbindInstance (this=0x7fff6758baf8, mapid=532, difficulty=<optimized out>, unload=unload@entry=true) at /home/wow/src/L4G_Core/src/game/Group.cpp:1811
#3  0x00000000007417fe in InstanceSaveManager::UnbindBeforeDelete (this=0x7ffff5116848) at /home/wow/src/L4G_Core/src/game/InstanceSaveMgr.cpp:74
#4  0x00000000004f984e in WorldRunnable::run (this=<optimized out>) at /home/wow/src/L4G_Core/src/Looking4GroupCore/WorldRunnable.cpp:80
#5  0x0000000000a4b1fa in ACE_Based::Thread::ThreadTask (param=0x7fffd089ae00) at /home/wow/src/L4G_Core/src/shared/Threading.cpp:183`