### PR TITLE
Move script for quest 8346 to EventAI

### DIFF
--- a/src/scripts/scripts/zone/eversong_woods/eversong_woods.cpp
+++ b/src/scripts/scripts/zone/eversong_woods/eversong_woods.cpp
@@ -17,12 +17,11 @@
 /* ScriptData
 SDName: Eversong_Woods
 SD%Complete: 100
-SDComment: Quest support: 8346, 8483, 8488, 8490
+SDComment: Quest support: 8483, 8488, 8490
 SDCategory: Eversong Woods
 EndScriptData */
 
 /* ContentData
-mobs_mana_tapped
 npc_prospector_anvilward
 npc_apprentice_mirveda
 npc_infused_crystal
@@ -30,31 +29,6 @@ EndContentData */
 
 #include "precompiled.h"
 #include "escort_ai.h"
-
-/*######
-## mobs_mana_tapped
-######*/
-
-struct mobs_mana_tappedAI : public ScriptedAI
-{
-    mobs_mana_tappedAI(Creature *c) : ScriptedAI(c) {}
-
-    void Reset() { }
-
-    void EnterCombat(Unit *who) { }
-
-    void SpellHit(Unit *caster, const SpellEntry *spell)
-    {
-        if( caster->GetTypeId() == TYPEID_PLAYER)
-            if( ((Player*)caster)->GetQuestStatus(8346) == QUEST_STATUS_INCOMPLETE && !((Player*)caster)->GetReqKillOrCastCurrentCount(8346, m_creature->GetEntry()) && spell->Id == 28734)
-                ((Player*)caster)->CastedCreatureOrGO(15468, m_creature->GetGUID(), spell->Id);
-        return;
-    }
-};
-CreatureAI* GetAI_mobs_mana_tapped(Creature *_Creature)
-{
-    return new mobs_mana_tappedAI (_Creature);
-}
 
 /*######
 ## npc_prospector_anvilward
@@ -760,11 +734,6 @@ CreatureAI* GetAI_npc_infused_crystalAI(Creature *_Creature)
 void AddSC_eversong_woods()
 {
     Script *newscript;
-
-    newscript = new Script;
-    newscript->Name="mobs_mana_tapped";
-    newscript->GetAI = &GetAI_mobs_mana_tapped;
-    newscript->RegisterSelf();
 
     newscript = new Script;
     newscript->Name= "npc_prospector_anvilward";


### PR DESCRIPTION
Doing it in the core like the old way meant we could not script the normal spells that the creatures use.

Delete the core script and replace it with:

```sql
-- ------------
-- Stop using the ugly core script for quest completion. It made it impossible to script the creature's normal spells
-- ------------

-- Arcane Wraith
UPDATE `creature_template` SET `AIName`='EventAI', `ScriptName`='' WHERE `entry`=15273;
DELETE FROM `creature_ai_scripts` WHERE `entryOrGUID` = 15273;
INSERT INTO `creature_ai_scripts` VALUES
('1527301','15273','8','0','100','0','28734','-1','0','0','16','15468','28734','6','0','0','0','0','0','0','0','0','Arcane Wraith - Quest Credit on Mana Tap Spellhit (Quest: 8346)'),
('1527302','15273','0','0','100','1','10100','16500','12700','24800','11','37361','1','0','0','0','0','0','0','0','0','0','Arcane Wraith - Cast Arcane Bolt');

-- Mana Wyrm
UPDATE `creature_template` SET `AIName`='EventAI', `ScriptName`='' WHERE `entry`=15274;
DELETE FROM `creature_ai_scripts` WHERE `entryOrGUID` = 15274;
INSERT INTO `creature_ai_scripts` VALUES
('1527401','15274','8','0','100','0','28734','-1','0','0','16','15468','28734','6','0','0','0','0','0','0','0','0','Mana Wyrm - Quest Credit on Mana Tap Spellhit (Quest: 8346)'),
('1527402','15274','0','0','75','1','12000','14000','56000','64000','11','25602','1','0','0','0','0','0','0','0','0','0','Mana Wyrm - Cast Faerie Fire');

-- Feral Tender
UPDATE `creature_template` SET `AIName`='EventAI', `ScriptName`='' WHERE `entry`=15294;
DELETE FROM `creature_ai_scripts` WHERE `entryOrGUID` = 15294;
INSERT INTO `creature_ai_scripts` VALUES
('1529401','15294','8','0','100','0','28734','-1','0','0','16','15468','28734','6','0','0','0','0','0','0','0','0','Feral Tender - Quest Credit on Mana Tap Spellhit (Quest: 8346)'),
('1529402','15294','2','0','100','1','50','0','15300','22900','11','31325','0','0','0','0','0','0','0','0','0','0','Feral Tender - Cast Renew at 50% HP');

-- Tainted Arcane Wraith
UPDATE `creature_template` SET `AIName`='EventAI', `ScriptName`='' WHERE `entry`=15298;
DELETE FROM `creature_ai_scripts` WHERE `entryOrGUID` = 15298;
INSERT INTO `creature_ai_scripts` VALUES
('1529801','15298','8','0','100','0','28734','-1','0','0','33','15468','6','0','0','0','0','0','0','0','0','0','Tainted Arcane Wraith - Quest Credit on Mana Tap Spellhit (Quest: 8346)'),
('1529802','15298','0','0','100','1','9000','18800','21100','32200','11','25603','1','0','0','0','0','0','0','0','0','0','Tainted Arcane Wraith - Cast Slow');

-- Felendren the Banished (3.0.3 Official Data)
DELETE FROM `creature_ai_texts` WHERE `entry`=-110;
INSERT INTO `creature_ai_texts` (`entry`,`content_default`,`sound`,`type`,`language`,`comment`,`emote`) VALUES
('-110','Take heart! Your friends will not long mourn your passing!','8506','0','0','15638','0');

UPDATE `creature_template` SET `AIName`='EventAI', `ScriptName`='' WHERE `entry`=15367;
DELETE FROM `creature_ai_scripts` WHERE `entryOrGUID` = 15367;
INSERT INTO `creature_ai_scripts` VALUES
('1536701','15367','4','0','100','0','0','0','0','0','1','-110','0','0','0','0','0','0','0','0','0','0','Felendren the Banished - Say on Aggro'),
('1536702','15367','0','0','100','1','9100','10600','20500','28600','11','16568','1','0','0','0','0','0','0','0','0','0','Felendren the Banished - Cast Mind Flay');
```

Will be added to Anon's migration