### PR TITLE
Faction queue fix

### DIFF
--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -435,12 +435,14 @@ bool World::RemoveQueuedPlayer(WorldSession* sess)
             {
                 session->SetInQueue(false);
                 session->SendAuthWaitQue(0);
-                iter = m_QueuedPlayer.erase(iter);
+                m_QueuedPlayer.erase(iter);
+                break;
             }
         }
     }
 
     iter = m_QueuedPlayer.begin();
+    position = 1;
     for (; iter != m_QueuedPlayer.end(); ++iter, ++position)
     {
         (*iter)->SendAuthWaitQue(position);

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -161,11 +161,12 @@ char const* WorldSession::GetPlayerName() const
 
 uint32 WorldSession::GetAccountTeamId() const
 {
+    uint32 team;
     QueryResultAutoPtr resultRace = RealmDataDatabase.PQuery("SELECT race FROM characters WHERE account ='%u' LIMIT 1", GetAccountId());
 
     if (!resultRace)
     {
-        return TEAM_NEUTRAL;
+        team = TEAM_NEUTRAL;
     }
     else
     {
@@ -178,15 +179,21 @@ uint32 WorldSession::GetAccountTeamId() const
             case RACE_NIGHTELF:
             case RACE_GNOME:
             case RACE_DRAENEI:
-                return TEAM_ALLIANCE;
+                team = TEAM_ALLIANCE;
+                break;
             case RACE_ORC:
             case RACE_UNDEAD_PLAYER:
             case RACE_TAUREN:
             case RACE_TROLL:
             case RACE_BLOODELF:
-                return TEAM_HORDE;
+                team = TEAM_HORDE;
+                break;
+            default:
+                team = TEAM_NEUTRAL;
         }
     }
+
+    return team;
 }
 
 void WorldSession::SaveOpcodesDisableFlags()


### PR DESCRIPTION
* Queue position number now updates correctly
* After allowing the appropriate account to enter the character select screen we break out of the loop (this was causing multiple people to get past the queue when only a single slot was opened up) 