### PR TITLE
Curse of Thule spell attribute

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3888,6 +3888,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->AttributesEx3 |= SPELL_ATTR_EX3_PLAYERS_ONLY;
                 break;
             case 3237: // Curse of Thule (Used by some gnolls in Tirisfall)
+            case 33493: // Mark of Malice (This attribute breaks EventAI, remove it for now until we find a solution)
                 spellInfo->Attributes &= ~SPELL_ATTR_ON_NEXT_SWING_2;
             default:
                 break;

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3887,6 +3887,8 @@ void SpellMgr::LoadSpellCustomAttr()
             case 31689:
                 spellInfo->AttributesEx3 |= SPELL_ATTR_EX3_PLAYERS_ONLY;
                 break;
+            case 3237: // Curse of Thule (Used by some gnolls in Tirisfall)
+                spellInfo->Attributes &= ~SPELL_ATTR_ON_NEXT_SWING_2;
             default:
                 break;
         }


### PR DESCRIPTION
With this attribute active they will just be forever casting, since they don't autoattack while casting so it will never go off.

Remove the attribute for now.