### PR TITLE
Spell Bad Poetry Mechanic

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3837,6 +3837,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->Mechanic = MECHANIC_HORROR;
                 break;
             case 8064: // Sleepy
+            case 29679: // Bad Poetry
                 spellInfo->Mechanic = MECHANIC_SLEEP;
                 break;
             case 29425: // Moroes Gouge


### PR DESCRIPTION
Id: 29679
Name: Bad Poetry
Description: Puts an enemy to sleep for up to $d. Any damage caused will
awaken the target. Only one target can be asleep at a time.
ToolTip: Asleep.