### PR TITLE
Fix to allow The Missing Diplomat escort quest to reset properly #3294

### DIFF
--- a/src/scripts/scripts/zone/wetlands/wetlands.cpp
+++ b/src/scripts/scripts/zone/wetlands/wetlands.cpp
@@ -118,7 +118,8 @@ struct npc_tapoke_slim_jahnAI : public npc_escortAI
                 me->DeleteThreatList();
                 me->CombatStop(true);
 
-                SetRun(false);
+                me->setDeathState(JUST_DIED);
+                me->Respawn();
             }
         }
     }


### PR DESCRIPTION
Fix to allow The Missing Diplomat escort quest to reset properly #3294
``UPDATE creature_template SET faction_A=35,faction_H=35 WHERE entry=4962;``