### PR TITLE
Fixed hunter pet experience rate gain #3258

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -20216,7 +20216,7 @@ bool Player::RewardPlayerAndGroupAtKill(Unit* pVictim)
 
                         pGroupGuy->GiveXP(itr_xp, pVictim);
                         if (Pet* pet = pGroupGuy->GetPet())
-                            pet->GivePetXP(itr_xp/2);
+                            pet->GivePetXP(itr_xp);
                     }
 
                     // quest objectives updated only for alive group member or dead but with not released body


### PR DESCRIPTION
Fixed hunter pet experience rate gain #3258 
http://wowwiki.wikia.com/wiki/Hunter_pet?oldid=1272015
"When the pet reaches the hunter's level, it stops gaining experience until the hunter levels up. Pets gain approximately the same experience from kills as an unrested character of the same level, and require a much lower amount of experience to level as a character of the same level."