### PR TITLE
Core/Quest: Fix quest completion for quests 9923, 9924, 9955

### DIFF
--- a/src/scripts/scripts/zone/nagrand/nagrand.cpp
+++ b/src/scripts/scripts/zone/nagrand/nagrand.cpp
@@ -681,7 +681,7 @@ CreatureAI* GetAI_mob_sparrowhawk(Creature *creature)
 enum CorkiCage
 {
     QUEST_HELP1            = 9923, // HELP!
-    NPC_CORKI_CAPITIVE1    = 18445,
+    NPC_CORKI_CAPITIVE1    = 18369,
     GO_CORKI_CAGE1         = 182349,
 
     QUEST_HELP2            = 9924, // Corki's Gone Missing Again!
@@ -689,7 +689,8 @@ enum CorkiCage
     GO_CORKI_CAGE2         = 182350,
 
     QUEST_HELP3            = 9955, // Cho'war the Pillager
-    NPC_CORKI_CAPITIVE3    = 18369,
+    NPC_CORKI_CAPITIVE3    = 18445,
+    NPC_CORKI_CAPITIVE3_CREDIT = 18444,
     GO_CORKI_CAGE3         = 182521,
 
     SAY_THANKS             = -1900133,
@@ -798,7 +799,7 @@ bool go_corki_cage(Player* player, GameObject* go)
                 Creature->GetMotionMaster()->MovePoint(0, -897.06f, 8688.03f, 170.47f);
                 break;
         }
-        player->KilledMonster(Creature->GetEntry(), Creature->GetGUID());
+        player->RewardPlayerAndGroupAtEvent(Creature->GetEntry() != NPC_CORKI_CAPITIVE3 ? Creature->GetEntry() : NPC_CORKI_CAPITIVE3_CREDIT, Creature);
         return false;
     }
     return true;


### PR DESCRIPTION
This solves: https://github.com/Looking4Group/L4G_Core/issues/3455

Requires the following queries to be run: (Will ask Anon to add to migration)
```sql
-- Fix quest template for Corki quests. (values from tbc-db)
UPDATE quest_template SET ReqCreatureOrGOId1=18369, ReqCreatureOrGOCount1=1, ReqSpellCast1=0 WHERE entry=9923;
UPDATE quest_template SET ReqCreatureOrGOId1=20812, ReqCreatureOrGOCount1=1, ReqSpellCast1=0 WHERE entry=9924;
UPDATE quest_template SET ReqCreatureOrGOId1=18444, ReqCreatureOrGOCount1=1, ReqSpellCast1=0 WHERE entry=9955;
-- Our id's were totally mixed up. Update positions from tbc-db
UPDATE creature SET position_x=-2563.89, position_y=6288.29, position_z=15.295, orientation=5.23599 WHERE guid=65786;
UPDATE creature SET position_x=-918.143, position_y=8663.94, position_z=172.542, orientation=0.523599 WHERE guid=65849;
-- Quest relations also wrong
UPDATE creature_questrelation SET quest=9923 WHERE id=18369;
UPDATE creature_questrelation SET quest=9955 WHERE id=18445;
UPDATE creature_involvedrelation SET id=18445 WHERE quest=9954;
```

Tested locally