### PR TITLE
Core/Creature: Add script for Debilitated Maghar Grunts (quest 9447)

### DIFF
--- a/src/scripts/scripts/zone/hellfire_peninsula/hellfire_peninsula.cpp
+++ b/src/scripts/scripts/zone/hellfire_peninsula/hellfire_peninsula.cpp
@@ -2553,6 +2553,98 @@ bool go_manni_cage(Player* player, GameObject* go)
     return true;
 }
 
+enum Maghar
+{
+    NPC_MAGHAR = 16846,
+    NPC_INJURED_MAGHAR = 16847,
+
+    SAY_THANKS1 = -1000709,
+    SAY_THANKS2 = -1000710,
+    SAY_THANKS3 = -1000711
+};
+struct npc_maghar_gruntAI : public ScriptedAI
+{
+    npc_maghar_gruntAI(Creature* pCreature) : ScriptedAI(pCreature) {}
+
+    void Reset()
+    {
+        spellHit = false;
+        lifeTimer = 120000;
+        tTimer = 3000;
+
+        me->SetStandState(UNIT_STAND_STATE_KNEEL);
+
+        if (me->GetEntry() == NPC_MAGHAR)
+            me->UpdateEntry(NPC_INJURED_MAGHAR);
+    }
+
+    bool spellHit;
+    uint32 lifeTimer;
+    uint32 tTimer;
+
+    void EnterCombat(Unit* /*who*/)
+    {
+    }
+
+    void SpellHit(Unit* pCaster, const SpellEntry* pSpell)
+    {
+        if (pSpell->Id == 29314 && !spellHit)
+        {
+            me->hasInvolvedQuest(9447);
+            me->SetStandState(UNIT_STAND_STATE_STAND);
+            switch (rand() % 3)
+            {
+            case 0:
+                DoScriptText(SAY_THANKS1, me, pCaster);
+                break;
+            case 1:
+                DoScriptText(SAY_THANKS2, me, pCaster);
+                break;
+            case 2:
+                DoScriptText(SAY_THANKS3, me, pCaster);
+                break;
+            }
+            spellHit = true;
+        }
+    }
+
+    void UpdateAI(const uint32 uiDiff)
+    {
+        if (!UpdateVictim())
+        {
+            if (me->GetEntry() == NPC_MAGHAR)
+            {
+                if (lifeTimer <= uiDiff)
+                {
+                    me->UpdateEntry(NPC_INJURED_MAGHAR);
+                    EnterEvadeMode();
+                    return;
+                }
+                else
+                    lifeTimer -= uiDiff;
+            }
+
+            if (spellHit == true)
+            {
+                if (tTimer <= uiDiff)
+                {
+                    me->UpdateEntry(NPC_MAGHAR);
+                    tTimer = 3000;
+                    spellHit = false;
+                }
+                else tTimer -= uiDiff;
+            }
+        }
+
+        DoMeleeAttackIfReady();
+    }
+};
+
+CreatureAI* GetAI_npc_maghar_grunt(Creature* pCreature)
+{
+    return new npc_maghar_gruntAI(pCreature);
+}
+
 void AddSC_hellfire_peninsula()
 {
     Script *newscript;
@@ -2735,5 +2827,10 @@ void AddSC_hellfire_peninsula()
     newscript = new Script;
     newscript->Name = "npc_manni";
     newscript->GetAI = &GetAI_npc_manni;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "npc_maghar_grunt";
+    newscript->GetAI = &GetAI_npc_maghar_grunt;
     newscript->RegisterSelf();
 }


### PR DESCRIPTION
* They now transform when healed, and the quest item can no longer be used on the same creature 10 times.
* Added texts and kneel/unkneel

* Solves: https://github.com/Looking4Group/L4G_Core/issues/964

Needs the following (will ask Anon to add to migration):
```sql
-- https://github.com/Looking4Group/L4G_Core/issues/964
DELETE FROM `script_texts` WHERE `entry`=-1000711;
INSERT INTO `script_texts` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (-1000711, 'You\'ve found a cure! We will crush our enemies!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 'Maghar Grunt SAY_THANKS1');
DELETE FROM `script_texts` WHERE `entry`=-1000710;
INSERT INTO `script_texts` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (-1000710, 'You\'ve restored my health! I\'m in your debt, $N.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 'Maghar Grunt SAY_THANKS2');
DELETE FROM `script_texts` WHERE `entry`=-1000709;
INSERT INTO `script_texts` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (-1000709, 'My strength.... is... returning!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 'Maghar Grunt SAY_THANKS3');
UPDATE creature_template SET ScriptName='npc_maghar_grunt' WHERE entry=16847;
```

* Thanks to OregonCore: https://github.com/OregonCore/OregonCore/blob/master/src/scripts/Outland/hellfire_peninsula.cpp#L2134