### PR TITLE
Triggered dispell fix (abolish poison)

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4660,7 +4660,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         uint32 dispelMask = 0;
 
                         for (uint8 i = 0; i < 3; ++i)
-                        {                  
+                        {
                             if (m_spellInfo->Effect[i] == SPELL_EFFECT_DISPEL)
                             {
                                 // itr through all dispel types and add them to mask

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4657,16 +4657,10 @@ SpellCastResult Spell::CheckCast(bool strict)
                     {
                         // Create dispel mask by dispel type
                         bool hasOtherEffects = false;
-                        bool isTriggered = false;
                         uint32 dispelMask = 0;
 
                         for (uint8 i = 0; i < 3; ++i)
-                        {
-                            if (m_spellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE)
-                            {
-                                isTriggered = true;
-                            }
-
+                        {                            
                             if (m_spellInfo->Effect[i] == SPELL_EFFECT_DISPEL)
                             {
                                 // itr through all dispel types and add them to mask
@@ -4678,7 +4672,7 @@ SpellCastResult Spell::CheckCast(bool strict)
 
                         // check if dispel makes sense
                         std::vector <Aura *> dispel_list;
-                        target->GetDispellableAuraList(m_caster, dispelMask, dispel_list);                        
+                        target->GetDispellableAuraList(m_caster, dispelMask, dispel_list);
                         if (dispel_list.empty() && !hasOtherEffects && !IsTriggeredSpell())
                             return SPELL_FAILED_NOTHING_TO_DISPEL;
                     }

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4657,10 +4657,16 @@ SpellCastResult Spell::CheckCast(bool strict)
                     {
                         // Create dispel mask by dispel type
                         bool hasOtherEffects = false;
+                        bool isTriggered = false;
                         uint32 dispelMask = 0;
 
                         for (uint8 i = 0; i < 3; ++i)
                         {
+                            if (m_spellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE)
+                            {
+                                isTriggered = true;
+                            }
+
                             if (m_spellInfo->Effect[i] == SPELL_EFFECT_DISPEL)
                             {
                                 // itr through all dispel types and add them to mask
@@ -4672,8 +4678,8 @@ SpellCastResult Spell::CheckCast(bool strict)
 
                         // check if dispel makes sense
                         std::vector <Aura *> dispel_list;
-                        target->GetDispellableAuraList(m_caster, dispelMask, dispel_list);
-                        if (dispel_list.empty() && !hasOtherEffects)
+                        target->GetDispellableAuraList(m_caster, dispelMask, dispel_list);                        
+                        if (dispel_list.empty() && !hasOtherEffects && !IsTriggeredSpell())
                             return SPELL_FAILED_NOTHING_TO_DISPEL;
                     }
                 }

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4660,7 +4660,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         uint32 dispelMask = 0;
 
                         for (uint8 i = 0; i < 3; ++i)
-                        {                            
+                        {                  
                             if (m_spellInfo->Effect[i] == SPELL_EFFECT_DISPEL)
                             {
                                 // itr through all dispel types and add them to mask


### PR DESCRIPTION
Triggered dispell spells like abolish poison disappeared after one tick if no valid debuff was present.