### PR TITLE
Core/Speedhack: adjustments 2

### DIFF
--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -62,8 +62,8 @@ int ACRequest::call()
 
     if (DetectSpeedHack(pPlayer))
     {
-        if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING)
-            && pPlayer->isAlive()) || !pPlayer->GetMapId() == 369)
+        if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive()) 
+            || !pPlayer->GetMapId() == 369)
 
         {
             sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -63,7 +63,7 @@ int ACRequest::call()
     if (DetectSpeedHack(pPlayer))
     {
         if (!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) 
-            && pPlayer->isAlive() && !pPlayer->GetMapId() == 369)
+            && pPlayer->isAlive() && pPlayer->GetMapId() != 369)
         {
             sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
             sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -62,8 +62,8 @@ int ACRequest::call()
 
     if (DetectSpeedHack(pPlayer))
     {
-        if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive()) 
-            || !pPlayer->GetMapId() == 369)
+        if (!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) 
+            && pPlayer->isAlive() && !pPlayer->GetMapId() == 369)
         {
             sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
             sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -62,15 +62,17 @@ int ACRequest::call()
 
     if (DetectSpeedHack(pPlayer))
     {
-        if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive()) 
-            || !pPlayer->GetMapId() == 369)
+        if (!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive())       
         {
-            sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
-            sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 
-                pPlayer->GetName(), pPlayer->GetGUIDLow(), pPlayer->GetSession()->GetAccountId());
-            // pPlayer->GetSession()->KickPlayer(); deactivated for further testing on live
+            if (!pPlayer->GetMapId() == 369)
+            {
+                sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
+                sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 
+                  pPlayer->GetName(), pPlayer->GetGUIDLow(), pPlayer->GetSession()->GetAccountId());
+                // pPlayer->GetSession()->KickPlayer(); deactivated for further testing on live
 
-            return -1;
+                return -1;
+            }
         }
     }
 

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -64,7 +64,6 @@ int ACRequest::call()
     {
         if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive()) 
             || !pPlayer->GetMapId() == 369)
-
         {
             sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
             sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -62,17 +62,15 @@ int ACRequest::call()
 
     if (DetectSpeedHack(pPlayer))
     {
-        if (!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive())       
+        if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) && pPlayer->isAlive()) 
+            || !pPlayer->GetMapId() == 369)
         {
-            if (!pPlayer->GetMapId() == 369)
-            {
-                sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
-                sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 
-                  pPlayer->GetName(), pPlayer->GetGUIDLow(), pPlayer->GetSession()->GetAccountId());
-                // pPlayer->GetSession()->KickPlayer(); deactivated for further testing on live
+            sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
+            sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 
+                pPlayer->GetName(), pPlayer->GetGUIDLow(), pPlayer->GetSession()->GetAccountId());
+            // pPlayer->GetSession()->KickPlayer(); deactivated for further testing on live
 
-                return -1;
-            }
+            return -1;
         }
     }
 

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -63,7 +63,7 @@ int ACRequest::call()
     if (DetectSpeedHack(pPlayer))
     {
         if (!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING) 
-            && pPlayer->isAlive() && pPlayer->GetMapId() != 369)
+            && pPlayer->isAlive())
         {
             sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
             sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 

--- a/src/game/AntiCheat.cpp
+++ b/src/game/AntiCheat.cpp
@@ -62,8 +62,9 @@ int ACRequest::call()
 
     if (DetectSpeedHack(pPlayer))
     {
-        if (!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING)
-            || !pPlayer->HasAuraType(SPELL_AURA_GHOST) || pPlayer->isAlive())
+        if ((!pPlayer->HasUnitMovementFlag(MOVEFLAG_FALLING | MOVEFLAG_FALLINGFAR | MOVEFLAG_SPLINE_ELEVATION | MOVEFLAG_SAFE_FALL | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_ONTRANSPORT | SPLINEFLAG_FLYINGING)
+            && pPlayer->isAlive()) || !pPlayer->GetMapId() == 369)
+
         {
             sWorld.SendGMText(LANG_ANTICHEAT, pPlayer->GetName(), pPlayer->GetName());
             sLog.outLog(LOG_CHEAT, "Player %s (GUID: %u / ACCOUNT_ID: %u) possible Speed Hack.", 

--- a/src/game/GridNotifiers.cpp
+++ b/src/game/GridNotifiers.cpp
@@ -127,7 +127,7 @@ void DynamicObjectUpdater::VisitHelper(Unit* target)
         if (i_check->IsFriendlyTo(target))
             return;
 
-        if (!spellInfo->AttributesEx3 == SPELL_ATTR_EX3_NO_INITIAL_AGGRO)
+        if (spellInfo->AttributesEx3 != SPELL_ATTR_EX3_NO_INITIAL_AGGRO)
             i_check->CombatStart(target);
 
     }

--- a/src/game/GridNotifiers.cpp
+++ b/src/game/GridNotifiers.cpp
@@ -127,7 +127,7 @@ void DynamicObjectUpdater::VisitHelper(Unit* target)
         if (i_check->IsFriendlyTo(target))
             return;
 
-        if (spellInfo->AttributesEx3 != SPELL_ATTR_EX3_NO_INITIAL_AGGRO)
+        if (!(spellInfo->AttributesEx3 & SPELL_ATTR_EX3_NO_INITIAL_AGGRO))
             i_check->CombatStart(target);
 
     }


### PR DESCRIPTION
not checking in deeprun tram anymore.
fixed logic (only check for alive players without those flags)