### PR TITLE
Database/Gameobject: Removed duplicate SSC bridge gameobjects

### DIFF
--- a/sql/updates/world/092_Remove_Duplicate_SSC_Bridge.sql
+++ b/sql/updates/world/092_Remove_Duplicate_SSC_Bridge.sql
@@ -1,0 +1,2 @@
+-- Remove duplicate SSC bridge objects
+DELETE FROM `gameobject` WHERE `guid` IN (78715, 78716, 78717);


### PR DESCRIPTION
Not sure why there are duplicate entries in the first place.