### PR TITLE
fix fast despawn

### DIFF
--- a/src/game/GameObject.cpp
+++ b/src/game/GameObject.cpp
@@ -1560,7 +1560,7 @@ void GameObject::HandleNonDbcSpell(uint32 spellId, Player* pUser)
 
             float x, y, z;
             pUser->GetNearPoint(x, y, z, 0.0f, 3.0f, frand(0, 2*M_PI));
-            if (Creature *pSummon = pUser->SummonCreature(entry, x, y, z, 0, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5000))
+            if (Creature *pSummon = pUser->SummonCreature(entry, x, y, z, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 600000))
                 pSummon->AI()->AttackStart(pUser);
 
             break;

--- a/src/game/GameObject.cpp
+++ b/src/game/GameObject.cpp
@@ -1560,7 +1560,7 @@ void GameObject::HandleNonDbcSpell(uint32 spellId, Player* pUser)
 
             float x, y, z;
             pUser->GetNearPoint(x, y, z, 0.0f, 3.0f, frand(0, 2*M_PI));
-            if (Creature *pSummon = pUser->SummonCreature(entry, x, y, z, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 600000))
+            if (Creature *pSummon = pUser->SummonCreature(entry, x, y, z, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 60000))
                 pSummon->AI()->AttackStart(pUser);
 
             break;


### PR DESCRIPTION
earlier it was possible to have time to loot quest item only if stay near npc - its bad for range(casters)