### PR TITLE
Guild logging fixes and fix an invalid SQL query

### DIFF
--- a/src/game/Guild.cpp
+++ b/src/game/Guild.cpp
@@ -724,8 +724,8 @@ void Guild::Disband()
     RealmDataDatabase.PExecute("DELETE FROM guild_bank_tab WHERE guildid = '%u'",Id);
     RealmDataDatabase.PExecute("DELETE FROM guild_bank_item WHERE guildid = '%u'",Id);
     RealmDataDatabase.PExecute("DELETE FROM guild_bank_right WHERE guildid = '%u'",Id);
-    RealmDataDatabase.PExecute("DELETE FROM guild_bank_eventlog WHERE guildid = '%u'",Id);
-    RealmDataDatabase.PExecute("DELETE FROM guild_eventlog WHERE guildid = '%u'",Id);
+    //RealmDataDatabase.PExecute("DELETE FROM guild_bank_eventlog WHERE guildid = '%u'",Id);
+    //RealmDataDatabase.PExecute("DELETE FROM guild_eventlog WHERE guildid = '%u'",Id);
     RealmDataDatabase.CommitTransaction();
     sGuildMgr.RemoveGuild(Id);
 }

--- a/src/game/Guild.cpp
+++ b/src/game/Guild.cpp
@@ -73,6 +73,8 @@ bool Guild::create(uint64 lGuid, std::string gname)
     MOTD = "No message set.";
     guildbank_money = 0;
     purchased_tabs = 0;
+    LogMaxGuid = 0;
+    GuildEventlogMaxGuid = 0;
 
     Id = sGuildMgr.GenerateGuildId();
 

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2484,7 +2484,7 @@ BanReturn World::BanAccount(BanMode mode, std::string nameIPOrMail, std::string 
         uint32 account = fieldsAccount[0].GetUInt32();
         uint32 permissions = PERM_PLAYER;
 
-        QueryResultAutoPtr resultAccPerm = AccountsDatabase.PQuery("SELECT permission_mask FROM account_permissions WHERE account_id = '%u' AND realm_id = '%u')", account, realmID);
+        QueryResultAutoPtr resultAccPerm = AccountsDatabase.PQuery("SELECT permission_mask FROM account_permissions WHERE account_id = '%u' AND realm_id = '%u'", account, realmID);
         if (resultAccPerm)
         {
             Field* fieldsAccId = resultAccPerm->Fetch();


### PR DESCRIPTION
* (https://github.com/Looking4Group/L4G_Core/commit/86bdf139ed7eecd2bc65cc1b950d18847c96bf75) When a new guild was created all attempts to log actions for that guild would fail until server was restarted because the LogGuid value would be higher than the size of an int
```
	1522423	2017-04-22 10:30:31 SQL: INSERT INTO guild_eventlog (guildid, LogGuid, EventType, PlayerGuid1, PlayerGuid2, NewRank, TimeStamp) VALUES ('XXX','2818601701','2','XXXXX','0','0','1492849831')
	1522424	2017-04-22 10:30:31 SQL ERROR: Duplicate entry 'XXX-2147483647' for key 'PRIMARY'
```

* (https://github.com/Looking4Group/L4G_Core/commit/f4bb0d705a9d61ff605fce46adee8e01578c2c02) Fix query with a random ')' that shouldn't exist
```
	1523094	2017-04-22 11:37:17 SQL: SELECT permission_mask FROM account_permissions WHERE account_id = 'XXXXXX' AND realm_id = 'X')
	1523095	2017-04-22 11:37:17 query ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1
```

* (https://github.com/Looking4Group/L4G_Core/commit/6880111ca0e1e9aee00d84d5619c192bd31af31c) Don't delete guild logs when guild is disbanded.