### PR TITLE
Increase despawn timer for Khadgar's Servant

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3931,6 +3931,9 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_DAMAGE | AURA_INTERRUPT_FLAG_CC | AURA_INTERRUPT_FLAG_HITBYSPELL;
                 spellInfo->CastingTimeIndex = 9;
                 break;
+            case 34444: // Khadgar's Servant, increase despawn time
+                spellInfo->DurationIndex = 30; // 1800000ms
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
* Fix the issue where the servant would sometimes despawn faster than the quest was completed if the player started the quest while unmounted.