### PR TITLE
Amanishi Scout Remove Flag Issue

### DIFF
--- a/src/scripts/scripts/zone/zulaman/zulaman.cpp
+++ b/src/scripts/scripts/zone/zulaman/zulaman.cpp
@@ -1235,6 +1235,7 @@ struct npc_amanishi_scoutAI : public ScriptedAI
     {
         me->SetVisibility(VISIBILITY_ON);
         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED);
+        me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
         DoScriptText(YELL_SCOUT_AGGRO, me);
         me->SetWalk(false);
         Unit *drums = FindCreature(22515, 50, me);
@@ -1258,7 +1259,7 @@ struct npc_amanishi_scoutAI : public ScriptedAI
                 if (urand(0, 100) < 25)
                 DoCast(me, SPELL_SUMMON_SENTRIES3, false);
 
-                SummonTimer = urand(2000, 3000);
+                SummonTimer = 5000;
             } else
                 SummonTimer -= diff;
         }

--- a/src/scripts/scripts/zone/zulaman/zulaman.cpp
+++ b/src/scripts/scripts/zone/zulaman/zulaman.cpp
@@ -1233,6 +1233,8 @@ struct npc_amanishi_scoutAI : public ScriptedAI
 
     void EnterCombat(Unit *who)
     {
+        me->SetVisibility(VISIBILITY_ON);
+        me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED);
         DoScriptText(YELL_SCOUT_AGGRO, me);
         me->SetWalk(false);
         Unit *drums = FindCreature(22515, 50, me);


### PR DESCRIPTION
if pulled accidently while pathing back invisible.
Mostly near the point where they remove it themselves on waypoint.

Was Pullable with Consecration, New Pathing Behavior needs to be
investigated in this case.

Was being able to be made visible while returning with AoE Mass Despell

Nerfed Spelltimer as he is now able to summon 2-3 Npcs and they dont come from the huts.