### PR TITLE
respawn steam pump overseer(if dead) on ironvine seeds use

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -2627,6 +2627,19 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                 }
                 return;
             }
+            case 31736:                                     // Ironvine Seeds
+            {
+                if (Unit* caster = GetCaster())
+                {
+                    Creature* pCreature = NULL;
+                    Looking4group::NearestCreatureEntryWithLiveStateInObjectRangeCheck creature_check(*caster, 18340, false, 15.0f, false);
+                    Looking4group::ObjectLastSearcher<Creature, Looking4group::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pCreature, creature_check);
+                    Cell::VisitGridObjects(caster, searcher, 15.0f);
+                    if (pCreature)
+                        pCreature->Respawn();
+                }
+                return;
+            }
         }
 
         // Earth Shield


### PR DESCRIPTION
http://www.wowhead.com/item=24330/drain-schematics#comments

> Every time you use the Iron Vine Seeds (//www.wowhead.com/?item=24355), a Steam Pump Overseer will spawn. Just it will not force a respawn of a Steam Pump Overseer if one is already up that you forcibly spawned

the chance of a drop should be approximately equal for all "Bloodscale"
http://www.wowhead.com/item=24330/drain-schematics#dropped-by
```
DELETE FROM `creature_loot_template` WHERE `item` = 24330;
INSERT INTO `creature_loot_template` VALUES (18088, 24330, 2, 0, 1, 1, 0, 0, 0);
INSERT INTO `creature_loot_template` VALUES (18089, 24330, 2, 0, 1, 1, 0, 0, 0);
INSERT INTO `creature_loot_template` VALUES (18340, 24330, 9, 0, 1, 1, 0, 0, 0);
INSERT INTO `creature_loot_template` VALUES (20088, 24330, 2, 0, 1, 1, 0, 0, 0);
INSERT INTO `creature_loot_template` VALUES (20089, 24330, 2, 0, 1, 1, 0, 0, 0);
INSERT INTO `creature_loot_template` VALUES (18123, 24330, 0.01, 0, 1, 1, 0, 0, 0);
```