### PR TITLE
Increase BG AFK report kick timer to 5 min

### DIFF
--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -2548,14 +2548,14 @@ enum MailResponseResult
 enum BattleGroundTypeId
 {
     BATTLEGROUND_TYPE_NONE      = 0,
-    BATTLEGROUND_AV             = 1,
-    BATTLEGROUND_WS             = 2,
-    BATTLEGROUND_AB             = 3,
-    BATTLEGROUND_NA             = 4,
-    BATTLEGROUND_BE             = 5,
-    BATTLEGROUND_AA             = 6,
-    BATTLEGROUND_EY             = 7,
-    BATTLEGROUND_RL             = 8
+    BATTLEGROUND_AV             = 1, // Alterac Valley
+    BATTLEGROUND_WS             = 2, // Warsong Gulch
+    BATTLEGROUND_AB             = 3, // Arathi Basin
+    BATTLEGROUND_NA             = 4, // Nagrand Arena
+    BATTLEGROUND_BE             = 5, // Blade's Edge Arena
+    BATTLEGROUND_AA             = 6, // All Arenas
+    BATTLEGROUND_EY             = 7, // Eye of the Storm
+    BATTLEGROUND_RL             = 8  // Ruins of Lordaeron
 };
 #define MAX_BATTLEGROUND_TYPE_ID 9
 

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3956,6 +3956,10 @@ void SpellMgr::LoadSpellCustomAttr()
             case 42463: //Seal of Vengeance additional fullstack DMG
                 spellInfo->EffectBasePoints[0] = 20;
                 break;
+            case 43680: // Idle (Received on BG AFK report)
+                spellInfo->DurationIndex = 5; // Increase duration to 5 min until we rework the system, to prevent players from getting kicked before match starts.
+                spellInfo->EffectAmplitude[0] = 300000;
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
Increase the kick timer to 5 min to prevent the AFK report abuse that kicks players before the BG has even begun. 

This should be a temporary solution until we figure out how we want to rework the AFK report system.

Please see https://github.com/Looking4Group/L4G_Core/issues/3623

and https://github.com/Looking4Group/L4G_Core/issues/418