### PR TITLE
bg afk

### DIFF
--- a/src/game/BattleGround.cpp
+++ b/src/game/BattleGround.cpp
@@ -186,6 +186,8 @@ void BattleGround::Update(uint32 diff)
                     if (itr->second.RemovePlayerTime >= TIME_TO_REMOVE_AFK_PLAYERS)
                         m_RemovedPlayers[itr->first] = 1;           // add to remove list (BG)
                 }
+                else
+                    itr->second.RemovePlayerTime = 0;                 // update last "idle" time
             }
             else
             {

--- a/src/game/BattleGround.cpp
+++ b/src/game/BattleGround.cpp
@@ -141,13 +141,11 @@ void BattleGround::Update(uint32 diff)
 
     m_StartTime += diff;
 
-
-
     if (GetRemovedPlayersSize())
     {
         for (std::map<uint64, uint8>::iterator itr = m_RemovedPlayers.begin(); itr != m_RemovedPlayers.end(); ++itr)
         {
-            Player *plr = sObjectMgr.GetPlayer(itr->first);
+            Player* plr = sObjectMgr.GetPlayer(itr->first);
             if (!plr)
             {
                 sLog.outDebug("BattleGround: Player " UI64FMTD " not found!", itr->first);
@@ -174,22 +172,26 @@ void BattleGround::Update(uint32 diff)
     // remove offline players from bg after 1 minutes && afk kick
     if (GetPlayersSize() && !m_Players.empty())
     {
-        BattleGroundPlayerMap::iterator itr, next;
-        for (itr = m_Players.begin(); itr != m_Players.end(); itr = next)
+        for (BattleGroundPlayerMap::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
         {
-            next = itr;
-            ++next;
-            Player *plr = sObjectMgr.GetPlayer(itr->first);
+            Player* plr = sObjectMgr.GetPlayer(itr->first);
             itr->second.LastOnlineTime += diff;
 
             if (plr)
+            {
                 itr->second.LastOnlineTime = 0;                 // update last online time
+                if (plr->GetDummyAura(SPELL_AURA_PLAYER_INACTIVE))
+                {
+                    itr->second.RemovePlayerTime += diff;
+                    if (itr->second.RemovePlayerTime >= TIME_TO_REMOVE_AFK_PLAYERS)
+                        m_RemovedPlayers[itr->first] = 1;           // add to remove list (BG)
+                }
+            }
             else
+            {
                 if (itr->second.LastOnlineTime >= MAX_OFFLINE_TIME)
                     m_RemovedPlayers[itr->first] = 1;           // add to remove list (BG)
-
-            if (plr && plr->HasAura(SPELL_AURA_PLAYER_INACTIVE))
-                RemovePlayerAtLeave(itr->first, true, true); // itr is erased here! Do not change any battleground's private variables !
+            }
         }
     }
 

--- a/src/game/BattleGround.h
+++ b/src/game/BattleGround.h
@@ -93,7 +93,8 @@ enum BattleGroundTimeIntervals
     RESPAWN_ONE_DAY                 = 86400,                // secs
     RESPAWN_IMMEDIATELY             = 0,                    // secs
     BUFF_RESPAWN_TIME               = 180,                  // secs
-    BG_HONOR_SCORE_TICKS            = 330                   // points
+    BG_HONOR_SCORE_TICKS            = 330,                  // points
+    TIME_TO_REMOVE_AFK_PLAYERS      = 60000                 // ms
 };
 
 enum BattleGroundBuffObjects
@@ -117,6 +118,7 @@ enum BattleGroundStatus
 struct BattleGroundPlayer
 {
     uint32  LastOnlineTime;                                 // for tracking and removing offline players from queue after 5 minutes
+    uint32  RemovePlayerTime;                               // for tracking and removing afk(reported) players from queue after 1 minutes
     uint32  Team;                                           // Player's team
 };
 

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -19041,7 +19041,7 @@ bool Player::CanReportAfkDueToLimit()
 void Player::ReportedAfkBy(Player* reporter)
 {
     BattleGround *bg = GetBattleGround();
-    if (!bg || bg != reporter->GetBattleGround() || GetBGTeam() != reporter->GetBGTeam())
+    if (!bg || (bg->GetStatus() != STATUS_IN_PROGRESS) || bg != reporter->GetBattleGround() || GetBGTeam() != reporter->GetBGTeam())
         return;
 
     // check if player has 'Idle' or 'Inactive' debuff
@@ -19057,9 +19057,6 @@ void Player::ReportedAfkBy(Player* reporter)
 
             // cast 'Idle' spell
             CastSpell(this, 43680, true);
-
-            if (!alive)
-                Kill(this, true);
 
             m_bgAfkReporter.clear();
         }


### PR DESCRIPTION
https://github.com/Looking4Group/L4G_Core/issues/3623
now afk reports until the bg starts are not counted(before fix in any state)
**kick players only if they have "Inactive" aura >1min**(before fix kicked on next bg update tick after aura apply)
