### PR TITLE
PetAI: Charge fixes & Logic improvement

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4353,13 +4353,13 @@ SpellCastResult Spell::CheckCast(bool strict)
                     target->GetPosition(dest);
 
                     float angle = m_caster->GetAngle(target) - m_caster->GetOrientation() - M_PI;
-                    m_caster->GetValidPointInAngle(dest, 2.0f, angle, false);
+                    m_caster->GetValidPointInAngle(dest, target->GetObjectSize() + m_caster->GetCombatReach(), angle, false);
                     _path.setPathLengthLimit(SpellMgr::GetSpellMaxRange(GetSpellInfo()) * 1.5f);
                     bool result = _path.calculate(dest.x, dest.y, dest.z);
 
-                    if (_path.getPathType() & PATHFIND_SHORT)
+                    if ((_path.getPathType() & PATHFIND_SHORT) || (target->GetDistance2d(_path.getActualEndPosition().x, _path.getActualEndPosition().y) > SpellMgr::GetSpellMaxRange(GetSpellInfo())))
                         return SPELL_FAILED_OUT_OF_RANGE;
-                    else if (!result && !m_caster->ToCreature()->isPet()) //Petcharge with mmaps doesn't work
+                    else if (!result)
                         return SPELL_FAILED_NOPATH;
                 }
                 break;

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -159,7 +159,7 @@ pEffect SpellEffects[TOTAL_SPELL_EFFECTS]=
     &Spell::EffectUnused,                                   // 93 SPELL_EFFECT_SUMMON_PHANTASM
     &Spell::EffectSelfResurrect,                            // 94 SPELL_EFFECT_SELF_RESURRECT
     &Spell::EffectSkinning,                                 // 95 SPELL_EFFECT_SKINNING
-    &Spell::EffectUnused,                                   // 96 SPELL_EFFECT_CHARGE
+    &Spell::EffectCharge,                                   // 96 SPELL_EFFECT_CHARGE
     &Spell::EffectSummonCritter,                            // 97 SPELL_EFFECT_SUMMON_CRITTER
     &Spell::EffectKnockBack,                                // 98 SPELL_EFFECT_KNOCK_BACK
     &Spell::EffectDisEnchant,                               // 99 SPELL_EFFECT_DISENCHANT
@@ -7408,7 +7408,7 @@ void Spell::EffectCharge(uint32 /*i*/)
         target->GetPosition(dest);
 
         float angle = m_caster->GetAngle(target) - m_caster->GetOrientation() - M_PI;
-        m_caster->GetValidPointInAngle(dest, 2.0f, angle, false);
+        m_caster->GetValidPointInAngle(dest, target->GetObjectSize() + m_caster->GetCombatReach(), angle, false);
         m_caster->GetMotionMaster()->MoveCharge(dest.x, dest.y, dest.z);
     }
     else
@@ -7439,7 +7439,7 @@ void Spell::EffectCharge2(uint32 /*i*/)
             target->GetPosition(dest);
 
             float angle = m_caster->GetAngle(target) - m_caster->GetOrientation() - M_PI;
-            m_caster->GetValidPointInAngle(dest, 2.0f, angle, false);
+            m_caster->GetValidPointInAngle(dest, target->GetObjectSize() + m_caster->GetCombatReach(), angle, false);
         }
 
         m_caster->GetMotionMaster()->MoveCharge(dest.x, dest.y, dest.z);


### PR DESCRIPTION
- now charge dest point depends on the model size of the target
- PetAI::Autocast:
-  - Dive, Dash, Furious Howl can be cast not only in combat
- - fix logic (prepared targets not always true and have corresponed value at the time of cast), it fix at least boar charge(autocast) and similar; warrior spellreflect vs pets autocast(previous to fix next spell  reflected)