### PR TITLE
Fix chain spawn location in Illhoof fight.

### DIFF
--- a/src/scripts/scripts/zone/karazhan/boss_terestian_illhoof.cpp
+++ b/src/scripts/scripts/zone/karazhan/boss_terestian_illhoof.cpp
@@ -298,8 +298,7 @@ struct boss_terestianAI : public ScriptedAI
                 if (pTarget->isAlive())
                 {
                     DoCast(pTarget, SPELL_SACRIFICE, true);
-                    //DoCast(pTarget, SPELL_SUMMON_DEMONCHAINS, true);
-                    m_creature->SummonCreature(NPC_DEMONCHAINS, pTarget->GetPositionX(), pTarget->GetPositionY(), pTarget->GetPositionZ(), 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 21000);
+                    DoCast(pTarget, SPELL_SUMMON_DEMONCHAINS, true);
 
                     if (Unit* Chain = FindCreature(NPC_DEMONCHAINS, 100, me))
                         if (Creature* Chains = Chain->ToCreature())


### PR DESCRIPTION
* Fix the issue where chains would not spawn in the middle of the room, but instead on the location player was before teleport.
* Use the real summoning spell instead of SummonCreature.
* Requires this query:
```sql
DELETE FROM `spell_target_position` WHERE `id`=30120;
INSERT INTO `spell_target_position` VALUES (30120, 532, -11234.2, -1698.46, 179.24, 0.67621);
```