### PR TITLE
Core/Player: Revived players shouldn't get attacked by creatures near corpse

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -1886,6 +1886,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             WorldPacket data;
             BuildTeleportAckMsg(data, x, y, z, orientation);
             GetSession()->SendPacket(&data);
+            SetPosition(x, y, z, orientation, true);
         }
 
         if (getFollowingGM())


### PR DESCRIPTION
Maybe this fixes other teleport related issues, too