### PR TITLE
Core/Mechanic: Update StealthDetect/Mod System

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -2452,6 +2452,11 @@ bool Player::IsInSameGroupWith(Player const* p) const
         GetGroup()->SameSubGroup((Player*)this, (Player*)p);
 }
 
+bool Player::IsInSameRaidWith(Player const* p) const
+{
+    return p == this || (GetGroup() != NULL && GetGroup() == p->GetGroup());
+}
+
 ///- If the player is invited, remove him. If the group if then only 1 person, disband the group.
 /// \todo Shouldn't we also check if there is no other invitees before disbanding the group?
 void Player::UninviteFromGroup()

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -1468,7 +1468,6 @@ void Player::Update(uint32 update_diff, uint32 p_time)
         if (update_diff >= m_DetectInvTimer)
         {
             HandleStealthedUnitsDetection();
-            m_DetectInvTimer = InArena() ? 1000 : 3000;
         }
         else
             m_DetectInvTimer -= update_diff;

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -2448,14 +2448,14 @@ bool Player::IsGroupVisiblefor (Player* p) const
 bool Player::IsInSameGroupWith(Player const* p) const
 {
     return  p == this || GetGroup() != nullptr && 
-    GetGroup() == p->GetGroup() &&
-    GetGroup()->SameSubGroup((Player*)this, (Player*)p);
+        GetGroup() == p->GetGroup() &&
+        GetGroup()->SameSubGroup((Player*)this, (Player*)p);
 }
 
 bool Player::IsInSameRaidWith(Player const* p) const
 {
     return p == this || (GetGroup() != nullptr &&
-    GetGroup() == p->GetGroup());
+        GetGroup() == p->GetGroup());
 }
 
 ///- If the player is invited, remove him. If the group if then only 1 person, disband the group.

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -2447,14 +2447,12 @@ bool Player::IsGroupVisiblefor (Player* p) const
 
 bool Player::IsInSameGroupWith(Player const* p) const
 {
-    return  p==this || GetGroup() != NULL &&
-        GetGroup() == p->GetGroup() &&
-        GetGroup()->SameSubGroup((Player*)this, (Player*)p);
+    return p == this || (GetGroup() != nullptr && GetGroup() == p->GetGroup());
 }
 
 bool Player::IsInSameRaidWith(Player const* p) const
 {
-    return p == this || (GetGroup() != NULL && GetGroup() == p->GetGroup());
+    return p == this || (GetGroup() != nullptr && GetGroup() == p->GetGroup());
 }
 
 ///- If the player is invited, remove him. If the group if then only 1 person, disband the group.

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -1468,6 +1468,7 @@ void Player::Update(uint32 update_diff, uint32 p_time)
         if (update_diff >= m_DetectInvTimer)
         {
             HandleStealthedUnitsDetection();
+            m_DetectInvTimer = InArena() ? 1000 : 2000;
         }
         else
             m_DetectInvTimer -= update_diff;

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -2447,12 +2447,15 @@ bool Player::IsGroupVisiblefor (Player* p) const
 
 bool Player::IsInSameGroupWith(Player const* p) const
 {
-    return p == this || (GetGroup() != nullptr && GetGroup() == p->GetGroup());
+    return  p == this || GetGroup() != nullptr && 
+    GetGroup() == p->GetGroup() &&
+    GetGroup()->SameSubGroup((Player*)this, (Player*)p);
 }
 
 bool Player::IsInSameRaidWith(Player const* p) const
 {
-    return p == this || (GetGroup() != nullptr && GetGroup() == p->GetGroup());
+    return p == this || (GetGroup() != nullptr &&
+    GetGroup() == p->GetGroup());
 }
 
 ///- If the player is invited, remove him. If the group if then only 1 person, disband the group.

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -1631,7 +1631,7 @@ class LOOKING4GROUP_EXPORT Player : public Unit
 
         bool IsGroupVisiblefor (Player* p) const;
         bool IsInSameGroupWith(Player const* p) const;
-        bool IsInSameRaidWith(Player const* p) const { return p==this || (GetGroup() != NULL && GetGroup() == p->GetGroup()); }
+        bool IsInSameRaidWith(Player const* p) const;
         void UninviteFromGroup();
         static void RemoveFromGroup(Group* group, uint64 guid);
         void RemoveFromGroup() { RemoveFromGroup(GetGroup(),GetGUID()); }

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -9944,7 +9944,7 @@ bool Unit::canDetectInvisibilityOf(Unit const* u, WorldObject const* viewPoint) 
 
 bool Unit::canDetectStealthOf(Unit const* target, WorldObject const* viewPoint, float distance) const
 {
-    if (hasUnitState(UNIT_STAT_STUNNED))
+    if (hasUnitState(UNIT_STAT_SIGHTLESS))
         return false;
 
     if (distance < 0.24f) //collision

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -9942,33 +9942,111 @@ bool Unit::canDetectInvisibilityOf(Unit const* u, WorldObject const* viewPoint) 
     return false;
 }
 
+float Unit::GetStealthDetectionValue() const
+{
+    float level = 0;
+    if (HasAura(19480, 0) || HasAura(19885, 0)) // Paranoia, Track Hidden
+        level += 30;
+    if (HasAura(20600, 0)) // Perception (Racial
+        level += 50;
+    if (HasAura(30894, 1)) // Heightened Senses (Rank 1)
+        level += 3;
+    if (HasAura(30895, 1)) // Heightened Senses (Rank 2)
+        level += 6;
+    if (HasAura(40273, 1)) // Stealth Detection (googles)
+        level += 5;
+    if (HasAura(23217, 1)) // Bloodvine Lens
+        level += 10;
+    if (HasAura(12418, 1)) // Catseye Ultra Goggles
+        level += 18;
+    if (HasAura(12608, 0)) // Cats elixir
+        level += 10;
+    if (HasAura(30249, 0)) // Hyper-Vision Goggles
+        level += 30;
+    if (HasAura(28496, 0)) // Greater Stealth Detection
+        level += 15;
+    if (HasAura(38551, 0)) // Distilled Stalker Sight
+        level += 15;
+
+
+    return level;
+}
+
+float Unit::GetStealthModifierValue() const
+{
+    float level = 0;
+    if (HasAura(11327, 0)) // Vanish (Rank 1)
+        level += 170;
+    if (HasAura(11329, 0)) // Vanish (Rank 2)
+        level += 270;
+    if (HasAura(26888, 0)) // Vanish (Rank 3)
+        level += 370;
+    if (HasAura(13958, 1)) // Master of Deception (Rank 1)
+        level += 3;
+    if (HasAura(13970, 1)) // Master of Deception (Rank 2)
+        level += 6;
+    if (HasAura(13971, 1)) // Master of Deception (Rank 3)
+        level += 9;
+    if (HasAura(13972, 1)) // Master of Deception (Rank 4)
+        level += 12;
+    if (HasAura(13973, 1)) // Master of Deception (Rank 5)
+        level += 15;
+    if (HasAura(16947, 1)) // Feral Instinct (Rank 1)
+        level += 5;
+    if (HasAura(16948, 1)) // Feral Instinct (Rank 2)
+        level += 10;
+    if (HasAura(16949, 1)) // Feral Instinct (Rank 3)
+        level += 15;
+    if (HasAura(21009, 1)) // Shadowmeld Passive (Racial Passive)
+        level += 5;
+
+    return level;
+}
+
 bool Unit::canDetectStealthOf(Unit const* target, WorldObject const* viewPoint, float distance) const
 {
-    if (hasUnitState(UNIT_STAT_SIGHTLESS))
+    if (!target)
         return false;
 
-    if (distance < 0.24f) //collision
+    if (hasUnitState(UNIT_STAT_SIGHTLESS)) 
+        return false;
+
+    if (GetTypeId() != TYPEID_PLAYER)
+    {
+        if (distance < 0.24f) //collision
+            return true;
+    }
+
+    if (GetTypeId() == TYPEID_PLAYER)
+    {
+        if (distance < 5.0f) //collision
+            return true;
+    }
+
+    if (HasAuraType(SPELL_AURA_DETECT_STEALTH))
         return true;
 
     if (!viewPoint->HasInArc(M_PI, target)) //behind
         return false;
-
-    if (HasAuraType(SPELL_AURA_DETECT_STEALTH))
-        return true;
 
     AuraList const& auras = target->GetAurasByType(SPELL_AURA_MOD_STALKED); // Hunter mark
     for (AuraList::const_iterator iter = auras.begin(); iter != auras.end(); ++iter)
         if ((*iter)->GetCasterGUID() == GetGUID())
             return true;
 
-    //Visible distance based on stealth value (stealth rank 4 300MOD, 10.5 - 3 = 7.5)
-    float visibleDistance = 7.5f;
+    //Visible distance based on stealth value (stealth hunter pet 300MOD, 10.5 - 3 = 7.5) new values for rogue stealth and druid prowl 400MOD 10.5 - 4 = 6.5f
+    float visibleDistance = 10.0f; // Default: 10.5f
     //Visible distance is modified by -Level Diff (every level diff = 1.0f in visible distance)
-    visibleDistance += float(getLevelForTarget(target)) - target->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH)/5.0f;
-    //-Stealth Mod(positive like Master of Deception) and Stealth Detection(negative like paranoia)
-    //based on wowwiki every 5 mod we have 1 more level diff in calculation
-    visibleDistance += (float)(GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_DETECT, 0) - target->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_LEVEL)) / 5.0f;
+    visibleDistance -= target->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH) / 100.0f;
+
+    visibleDistance += float(getLevel() - target->getLevel()); // every level difference will give you 1 yard detection or subtlety
+                                                               // Stealth Mod(positive like Master of Deception) and Stealth Detection(negative like paranoia)
+                                                               // based on wowwiki every 5 mod we have 1 more level diff in calculation
+    visibleDistance += (float)GetStealthDetectionValue() / 5.0f - target->GetTotalAuraModifier(SPELL_AURA_MOD_STEALTH_LEVEL) / 5.0f;
     visibleDistance = visibleDistance > MAX_PLAYER_STEALTH_DETECT_RANGE ? MAX_PLAYER_STEALTH_DETECT_RANGE : visibleDistance;
+
+    if (!HasInArc(M_PI, target))
+        visibleDistance /= 4;
 
     return distance < visibleDistance;
 }

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -9950,6 +9950,7 @@ bool Unit::canDetectStealthOf(Unit const* target, WorldObject const* viewPoint, 
     if (hasUnitState(UNIT_STAT_SIGHTLESS)) 
         return false;
 
+    if (target->HasAuraTypeWithFamilyFlags(SPELL_AURA_MOD_STEALTH, SPELLFAMILY_ROGUE, SPELLFAMILYFLAG_ROGUE_VANISH) && distance > 0.24f)
         return false;
 
     if (distance < 0.24f && HasInArc(M_PI, target)) //collision

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1407,6 +1407,8 @@ class LOOKING4GROUP_IMPORT_EXPORT Unit : public WorldObject
         virtual bool canSeeOrDetect(Unit const* u, WorldObject const*, bool detect, bool inVisibleList = false, bool is3dDistance = true) const;
 
         bool canDetectInvisibilityOf(Unit const* u, WorldObject const*) const;
+        float GetStealthDetectionValue() const;
+        float GetStealthModifierValue() const;
         bool canDetectStealthOf(Unit const* u, WorldObject const*, float distance) const;
 
         // virtual functions for all world objects types

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1407,8 +1407,6 @@ class LOOKING4GROUP_IMPORT_EXPORT Unit : public WorldObject
         virtual bool canSeeOrDetect(Unit const* u, WorldObject const*, bool detect, bool inVisibleList = false, bool is3dDistance = true) const;
 
         bool canDetectInvisibilityOf(Unit const* u, WorldObject const*) const;
-        float GetStealthDetectionValue() const;
-        float GetStealthModifierValue() const;
         bool canDetectStealthOf(Unit const* u, WorldObject const*, float distance) const;
 
         // virtual functions for all world objects types

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1053,6 +1053,7 @@ void World::LoadConfigSettings(bool reload)
     m_configs[CONFIG_INSTANT_LOGOUT] = sConfig.GetIntDefault("InstantLogout", PERM_GMT);
 
     m_configs[CONFIG_GROUPLEADER_RECONNECT_PERIOD] = sConfig.GetIntDefault("GroupLeaderReconnectPeriod", 180);
+    m_configs[CONFIG_GROUP_VISIBILITY] = sConfig.GetIntDefault("Visibility.GroupMode", 0);
 
     m_VisibleObjectGreyDistance = sConfig.GetFloatDefault("Visibility.Distance.Grey.Object", 10);
     if (m_VisibleObjectGreyDistance >  MAX_VISIBILITY_DISTANCE)


### PR DESCRIPTION
Composed of Different Stealth System Adjustments from Trinitycore_Azshara_2.4.3 and SkyFire243.

---

- Fixed RaidGroup Visibilty for Stealthed Players Visibility.GroupMode seems to not work for value 1 (raid members 100% auto detect invisible player from same raid) so default is taken which only allows subgroup visibility.

Stealthed Players in other Groups can be seen and healed and targeted via RaidInterface and healed/buffed.
![unbenannt](https://cloud.githubusercontent.com/assets/19734826/26285557/8925f35c-3e52-11e7-8ad6-ddc79ff5fa73.PNG)

- Adjust Detecttimer to match Energy Tick Timer, which benefits both stealthed players and detecting units.

- Units with (UNIT_STAT_CONFUSED | UNIT_STAT_STUNNED | UNIT_STAT_FLEEING | UNIT_STAT_CHARGING) cant detect Stealth anymore, befor only UNIT_STAT_STUNNED.

- Tryfix Improve Situation for Vanish Case

- Tryfix Improvements for Approching Targets from Behind (Collision, Bounding Radius related) as Units were able to detect Rogues which Shadowstep behind them as the position they were teleported to was in their LOS eventhough they are standing behind them.

- From Testing visibleDistance = 10.5f; might need to be increased to 11.0f to get the 7.5f visibileDistance with 300MOD.

---

# ToTest:

- Test Stealth Detect / Stealth Mod Talents

- [ ] Paranoia, Track Hidden level += 30; 19480,19885

- [ ] Perception (Racial) level += 50; 20600

- [x] Heightened Senses (Rank 1) level += 3; 30894

- [x] Heightened Senses (Rank 2) level += 6; 30895

- [ ] Stealth Detection (googles) level += 5; 40273

- [ ] Bloodvine Lens level += 10; 23217

- [ ] Catseye Ultra Goggles level += 18; 12418

- [ ] Cats elixir level += 10; 12608

- [ ] Hyper-Vision Goggles level += 30; 30249

- [ ] Greater Stealth Detection level += 15; 28496

- [ ] Distilled Stalker Sight level += 15; 38551

---

- [ ] Vanish (Rank 1) level += 170; 11327

- [ ] Vanish (Rank 2) level += 270; 11329

- [ ] Vanish (Rank 3) level += 370; 26888

- [x] Master of Deception (Rank 1) level += 3; 13958

- [x] Master of Deception (Rank 2) level += 6; 13970

- [x] Master of Deception (Rank 3) level += 9; 13971

- [x] Master of Deception (Rank 4) level += 12; 13972

- [x] Master of Deception (Rank 5) level += 15; 13973

- [ ] Feral Instinct (Rank 1) level += 5; 16947

- [ ] Feral Instinct (Rank 2) level += 10; 16948

- [ ] Feral Instinct (Rank 3) level += 15; 16949

- [ ] Shadowmeld Passive (Racial Passive) level += 5; 21009

---

# Sources:

http://www.wowwiki.com/Stealth_%28mechanic%29?oldid=1512438

- https://github.com/romseguy/Trinitycore_Azshara_2.4.3/commit/757b9020636c944599a6adacba225e4f940b35f9

- https://github.com/SkyFire243/Core/commit/c19361df8bc51a7370864b6b61259756b06b841d

- https://github.com/SkyFire243/SkyFire_one/commit/02f4b355597c8e3c0b5b964050b64814e2410334