### PR TITLE
Remove Lurker InVisibility on Death

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lurker_below.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/boss_lurker_below.cpp
@@ -285,6 +285,7 @@ struct boss_the_lurker_belowAI : public BossAI
 
         instance->SetData(DATA_LURKER_EVENT, DONE);
         me->RemoveAurasDueToSpell(SPELL_SUBMERGE);
+        me->SetVisibility(VISIBILITY_ON);
     }
 
     void SummonAdds()


### PR DESCRIPTION
when dying to dots in phase 2

still seems to be missing loot sparkles, but can be seen and looted by right clicking.