### PR TITLE
SSC/InstanceScript - Bridge to Vashj remains open after crash/restart when consoles are interacted with

### DIFF
--- a/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
+++ b/src/scripts/scripts/zone/coilfang_resevoir/serpent_shrine/instance_serpent_shrine.cpp
@@ -174,7 +174,10 @@ struct instance_serpentshrine_cavern : public ScriptedInstance
             case CONSOLE_BRIDGE: // Lady Vashj Bridge Console
                 BridgeConsoleGuid = go->GetGUID();
                 if ((GetData(DATA_HYDROSS_EVENT) == SPECIAL) && (GetData(DATA_LURKER_EVENT) == SPECIAL) && (GetData(DATA_LEOTHERAS_EVENT) == SPECIAL) && (GetData(DATA_KARATHRESS_EVENT) == SPECIAL) && (GetData(DATA_MOROGRIM_EVENT) == SPECIAL))
+                {
                     HandleGameObject(0, true, go);
+                    go->SetLootState(GO_ACTIVATED);
+                }
                 break;
             case 184203: // Doodad_Coilfang_Raid_Bridge_Part01
                 BridgePartGuids[0] = go->GetGUID();


### PR DESCRIPTION
### Issue
If the bridge is opened and the server restarts then the consoles are interactable again and toggle the gate to close.
Certain guilds decided that instead of simply crossing the bridge that was open and fighting Lady Vashj, they'd fiddle with consoles and lock themselves out of a Lady Vashj fight until the next restart or GM intervention.

### Fix
If the bridge is opened automatically after a restart then the LootState is set to `GO_ACTIVATED` which means that whilst you can still interact with the consoles (go ahead - press them all you want!) the gate should no longer close.

![](http://i.imgur.com/XsIIplL.png)

This was never an issue for guilds that could clear SSC in one night  :smiling_imp: