### PR TITLE
Fix Respecc token not working at most rogue trainers.

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -1014,6 +1014,10 @@ void Creature::prepareGossipMenu(Player *pPlayer,uint32 gossipid)
                         if (!isCanTrainingAndResetTalentsOf(pPlayer) || !sWorld.getConfig(CONFIG_CUSTOM_TALENT_RESET_TOKEN) || pPlayer->HasItemCount(1000021, 1)) // Don't allow the player to buy two tokens
                             cantalking = false;
                         break;
+                    case GOSSIP_OPTION_ROGUE_LETTER:
+                        if (pPlayer->getClass() != CLASS_ROGUE || pPlayer->getLevel() < 24 || pPlayer->HasItemCount(17126, 1) || pPlayer->GetQuestRewardStatus(6681) || pPlayer->IsActiveQuest(6681))
+                            cantalking = false;
+                        break;
                     default:
                         sLog.outLog(LOG_DB_ERR, "Creature %u (entry: %u) have unknown gossip option %u",GetDBTableGUIDLow(),GetEntry(),gso->Action);
                         break;
@@ -1193,6 +1197,11 @@ void Creature::OnGossipSelect(Player* player, uint32 option)
 
             player->PlayerTalkClass->CloseGossip();
             break;
+        }
+        case GOSSIP_OPTION_ROGUE_LETTER:
+        {
+            player->PlayerTalkClass->CloseGossip();
+            player->CastSpell(player, 21100, false);
         }
         default:
             OnPoiSelect(player, gossip);

--- a/src/game/Creature.h
+++ b/src/game/Creature.h
@@ -64,7 +64,8 @@ enum Gossip_Option
     GOSSIP_OPTION_UNLEARNPETSKILLS  = 17,                   //UNIT_NPC_FLAG_TRAINER (bonus option for GOSSIP_OPTION_TRAINER)
     GOSSIP_OPTION_OUTDOORPVP        = 18,                   //added by code (option for outdoor pvp creatures)
     GOSSIP_OPTION_UNLEARNTALENTS_C  = 19,                   //Custom talent reset token feature
-    GOSSIP_OPTION_UNLEARNTALENTS_CB = 20                    //Gossip option to buy the custom talent reset token
+    GOSSIP_OPTION_UNLEARNTALENTS_CB = 20,                   //Gossip option to buy the custom talent reset token
+    GOSSIP_OPTION_ROGUE_LETTER      = 21                    //Gossip option to get item 17126 for quest 6681 from any rogue trainer
 };
 
 enum Gossip_Guard

--- a/src/scripts/scripts/npc/npcs_special.cpp
+++ b/src/scripts/scripts/npc/npcs_special.cpp
@@ -32,7 +32,6 @@ npc_guardian                100%    guardianAI used to prevent players from acce
 npc_injured_patient         100%    patients for triage-quests (6622 and 6624)
 npc_doctor                  100%    Gustaf Vanhowzen and Gregory Victor, quest 6622 and 6624 (Triage)
 npc_mount_vendor            100%    Regular mount vendors all over the world. Display gossip if player doesn't meet the requirements to buy
-npc_rogue_trainer           80%     Scripted trainers, so they are able to offer item 17126 for class quest 6681
 npc_sayge                   100%    Darkmoon event fortune teller, buff player based on answers given
 npc_snake_trap_serpents     80%     AI for snakes that summoned by Snake Trap
 npc_flight_master           100%    AI for flight masters.
@@ -778,51 +777,6 @@ bool GossipSelect_npc_mount_vendor(Player *player, Creature *_Creature, uint32 s
     if (action == GOSSIP_ACTION_TRADE)
         player->SEND_VENDORLIST( _Creature->GetGUID() );
 
-    return true;
-}
-
-/*######
-## npc_rogue_trainer
-######*/
-
-bool GossipHello_npc_rogue_trainer(Player *player, Creature *_Creature)
-{
-    if( _Creature->isQuestGiver() )
-        player->PrepareQuestMenu( _Creature->GetGUID() );
-
-    if( _Creature->isTrainer() )
-        player->ADD_GOSSIP_ITEM(2, GOSSIP_TEXT_TRAIN, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRAIN);
-
-    if( _Creature->isCanTrainingAndResetTalentsOf(player) )
-        player->ADD_GOSSIP_ITEM(2, "I wish to unlearn my talents", GOSSIP_SENDER_MAIN, GOSSIP_OPTION_UNLEARNTALENTS);
-
-    if( player->getClass() == CLASS_ROGUE && player->getLevel() >= 24 && !player->HasItemCount(17126,1) && !player->GetQuestRewardStatus(6681) )
-    {
-        player->ADD_GOSSIP_ITEM(0, "<Take the letter>", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF+1);
-        player->SEND_GOSSIP_MENU(5996, _Creature->GetGUID());
-    }
-    else
-        player->SEND_GOSSIP_MENU(_Creature->GetNpcTextId(), _Creature->GetGUID());
-
-    return true;
-}
-
-bool GossipSelect_npc_rogue_trainer(Player *player, Creature *_Creature, uint32 sender, uint32 action)
-{
-    switch( action )
-    {
-    case GOSSIP_ACTION_INFO_DEF+1:
-        player->CLOSE_GOSSIP_MENU();
-        player->CastSpell(player,21100,false);
-        break;
-    case GOSSIP_ACTION_TRAIN:
-        player->SEND_TRAINERLIST( _Creature->GetGUID() );
-        break;
-    case GOSSIP_OPTION_UNLEARNTALENTS:
-        player->CLOSE_GOSSIP_MENU();
-        player->SendTalentWipeConfirm( _Creature->GetGUID() );
-        break;
-    }
     return true;
 }
 
@@ -3317,12 +3271,6 @@ void AddSC_npcs_special()
     newscript->Name = "npc_mount_vendor";
     newscript->pGossipHello =  &GossipHello_npc_mount_vendor;
     newscript->pGossipSelect = &GossipSelect_npc_mount_vendor;
-    newscript->RegisterSelf();
-
-    newscript = new Script;
-    newscript->Name = "npc_rogue_trainer";
-    newscript->pGossipHello =  &GossipHello_npc_rogue_trainer;
-    newscript->pGossipSelect = &GossipSelect_npc_rogue_trainer;
     newscript->RegisterSelf();
 
     newscript = new Script;


### PR DESCRIPTION
* Caused by core script npc_rogue_trainer overwriting the gossip menu.
* Moved the letter gossip option to now be available globally for all rogue trainers instead of in a npcs_special script
* Resolves: https://github.com/Looking4Group/L4G_Core/issues/3807
* Requires the following DB queries to be run:

```sql
UPDATE `creature_template` SET `ScriptName`='' WHERE `ScriptName`='npc_rogue_trainer';

DELETE FROM `npc_option` WHERE `id`=54;
INSERT INTO `npc_option` (`id`, `npcflag`, `action`, `option_text`) VALUES
('54', '16', '21', '<Take the letter>');
```