### PR TITLE
Improve AI for Azaloth and Sunfury Warlocks

### DIFF
--- a/src/scripts/scripts/zone/shadowmoon_valley/shadowmoon_valley.cpp
+++ b/src/scripts/scripts/zone/shadowmoon_valley/shadowmoon_valley.cpp
@@ -49,17 +49,20 @@ EndContentData */
 # mob_azaloth
 #####*/
 
-#define SPELL_CLEAVE                   40504
-#define SPELL_CRIPPLE                  11443
-#define SPELL_RAIN_OF_FIRE             38741
-#define SPELL_WARSTOMP                 38750
-#define SPELL_BANISH                   37833
-#define TIME_TO_BANISH                 60000
-#define SPELL_VISUAL_BANISH            38722
+enum
+{
+    SPELL_CLEAVE = 40504,
+    SPELL_CRIPPLE = 11443,
+    SPELL_RAIN_OF_FIRE = 38741,
+    SPELL_WARSTOMP = 38750,
+    SPELL_BANISH = 37833,
+    SPELL_UBANISH = 37834,
+    TIME_TO_BANISH = 60000
+};
 
 struct mob_azalothAI : public ScriptedAI
 {
-    mob_azalothAI(Creature* c) : ScriptedAI(c)   {}
+    mob_azalothAI(Creature* c) : ScriptedAI(c) {}
 
     uint32 cleave_timer;
     uint32 cripple_timer;
@@ -67,87 +70,96 @@ struct mob_azalothAI : public ScriptedAI
     uint32 warstomp_timer;
     uint64 banish_timer;
 
-
     void JustRespawned()
     {
-        DoCast(m_creature,SPELL_BANISH);
-        std::list<Creature*> warlocks = FindAllCreaturesWithEntry(21503, 30.0f);
-        for (std::list<Creature*>::iterator itr = warlocks.begin(); itr != warlocks.end(); ++itr)
-            (*itr)->CastSpell(me,SPELL_VISUAL_BANISH, false);
+        DoCast(m_creature, SPELL_BANISH);
     }
 
     void EnterCombat()
     {
-        DoCast(m_creature->getVictim(),SPELL_CRIPPLE);
-        banish_timer  = TIME_TO_BANISH;
+        DoCast(m_creature->getVictim(), SPELL_CRIPPLE);
+        banish_timer = TIME_TO_BANISH;
     }
 
     void Reset()
     {
-        cleave_timer  = 6000;
+        cleave_timer = 6000;
         cripple_timer = 18000;
-        rain_timer    = 15000;
-        warstomp_timer= 10000;
-        banish_timer  = TIME_TO_BANISH;
+        rain_timer = 15000;
+        warstomp_timer = 10000;
+    }
+
+    void SpellHit(Unit *caster, const SpellEntry *spell)
+    {
+        if (spell->Id == SPELL_UBANISH)
+        {
+            if (caster->GetTypeId() == TYPEID_PLAYER)
+            {
+                if (Player* plr = caster->ToPlayer())
+                {
+                    // The Aldor
+                    if (plr->hasQuest(10637))
+                    {
+                        if (plr->GetQuestStatus(10637) == QUEST_STATUS_INCOMPLETE)
+                            plr->SetQuestStatus(10637, QUEST_STATUS_COMPLETE);
+                    }
+                    // The Scryers
+                    else if (plr->hasQuest(10688))
+                    {
+                        if (plr->GetQuestStatus(10688) == QUEST_STATUS_INCOMPLETE)
+                            plr->SetQuestStatus(10688, QUEST_STATUS_COMPLETE);
+                    }
+                }
+            }
+        }
     }
 
     void UpdateAI(const uint32 diff)
     {
-        if (banish_timer < diff)
+        if (banish_timer <= diff)
         {
-            DoCast(m_creature,SPELL_BANISH);
-            banish_timer  = TIME_TO_BANISH;
-        }
-
-        std::list<Creature*> warlocks = FindAllCreaturesWithEntry(21503, 20.0f);
-        for (std::list<Creature*>::iterator itr = warlocks.begin(); itr != warlocks.end(); ++itr)
-        {
-            (*itr)->GetMotionMaster()->Clear(false);
-            (*itr)->StopMoving();
-            (*itr)->CastSpell(me,SPELL_VISUAL_BANISH, false);
+            DoCast(m_creature, SPELL_BANISH);
+            banish_timer = TIME_TO_BANISH;
         }
 
         if (!UpdateVictim())
         {
-            banish_timer-=diff;
+            banish_timer -= diff;
             return;
         }
 
-        //spell cleave
-        if (cleave_timer<diff)
+        if (cleave_timer <= diff)
         {
             DoCast(m_creature->getVictim(), SPELL_CLEAVE);
-            cleave_timer  = 6000;
+            cleave_timer = 6000;
         }
         else
-            cleave_timer-=diff;
+            cleave_timer -= diff;
 
-        //spell cripple
-        if (cripple_timer<diff)
+        if (cripple_timer <= diff)
         {
             DoCast(m_creature->getVictim(), SPELL_CRIPPLE);
-           cripple_timer = 40000;
+            cripple_timer = 40000;
         }
         else
-            cripple_timer-=diff;
+            cripple_timer -= diff;
 
-        //spell rain of fire
-        if (rain_timer<diff)
+        if (rain_timer <= diff)
         {
             DoCast(m_creature->getVictim(), SPELL_RAIN_OF_FIRE);
-            rain_timer    = 15000;
+            rain_timer = 15000;
         }
         else
-            rain_timer-=diff;
+            rain_timer -= diff;
 
-        //spell warstomp
-        if (warstomp_timer<diff)
+
+        if (warstomp_timer <= diff)
         {
             DoCast(m_creature->getVictim(), SPELL_WARSTOMP);
-            warstomp_timer= 10000;
+            warstomp_timer = 10000;
         }
         else
-            warstomp_timer-=diff;
+            warstomp_timer -= diff;
 
         DoMeleeAttackIfReady();
     }
@@ -156,6 +168,91 @@ struct mob_azalothAI : public ScriptedAI
 CreatureAI* GetAI_mob_azaloth(Creature *_creature)
 {
     return new mob_azalothAI(_creature);
+}
+
+/*#####
+# mob_sunfury_warlock
+#####*/
+
+enum 
+{
+    SPELL_SHADOWBOLT = 9613,
+    SPELL_INCINERATE = 32707,
+    SPELL_VISUAL_BANISH = 38722
+};
+
+struct mob_sunfury_warlockAI : public ScriptedAI
+{
+    mob_sunfury_warlockAI(Creature* c) : ScriptedAI(c) {}
+
+    uint32 ReadyToCast;
+    uint32 CheckChanneling;
+
+    void Reset()
+    {
+        ReadyToCast = 3000;
+        CheckChanneling = 5000;
+    }
+
+    void EnterCombat(Unit* who)
+    {
+        me->InterruptNonMeleeSpells(false);
+        me->clearUnitState(UNIT_STAT_CASTING);
+        ScriptedAI::EnterCombat(who);
+    }
+
+    void UpdateAI(const uint32 diff)
+    {
+        if (!me->isInCombat())
+        {
+            if (CheckChanneling <= diff)
+            {
+                VisualCast();
+                CheckChanneling = 5000;
+            }
+            else CheckChanneling -= diff;
+        }
+
+        if (!UpdateVictim())
+            return;
+
+        if (ReadyToCast <= diff)
+        {
+            switch (urand(0, 1))
+            {
+            case 0:
+                DoCast(me->getVictim(), SPELL_SHADOWBOLT);
+                break;
+            case 1:
+                DoCast(me->getVictim(), SPELL_INCINERATE);
+                break;
+            }
+            ReadyToCast = 3000 + urand(0, 2000);
+        }
+        else ReadyToCast -= diff;
+
+        DoMeleeAttackIfReady();
+    }
+
+    void VisualCast()
+    {
+        if (Unit* Azaloth = GetClosestCreatureWithEntry(me, 21506, 20.0f, true))
+        {
+            if (Azaloth->isAlive() && Azaloth->HasAura(SPELL_BANISH))
+            {
+                if (!me->hasUnitState(UNIT_STAT_CASTING))
+                {
+                    me->CastSpell(Azaloth, SPELL_VISUAL_BANISH, false);
+                    me->addUnitState(UNIT_STAT_CASTING);
+                }
+            }
+        }
+    }
+};
+
+CreatureAI* GetAI_mob_sunfury_warlock(Creature *_creature)
+{
+    return new mob_sunfury_warlockAI(_creature);
 }
 
 
@@ -3538,6 +3635,11 @@ void AddSC_shadowmoon_valley()
     newscript = new Script;
     newscript->Name = "mob_azaloth";
     newscript->GetAI = &GetAI_mob_azaloth;
+    newscript->RegisterSelf();
+
+    newscript = new Script;
+    newscript->Name = "mob_sunfury_warlock";
+    newscript->GetAI = &GetAI_mob_sunfury_warlock;
     newscript->RegisterSelf();
 
     newscript = new Script;


### PR DESCRIPTION
Thanks to playtbc: https://bitbucket.org/Caboon/playcore-official/commits/78c4997cbec26a5eb0ec44842fa2aec76606b229

Solves https://github.com/Looking4Group/L4G_Core/issues/3812
This issue still remains: https://github.com/Looking4Group/L4G_Core/issues/2169. I was not able to solve it.

Needs the following DB queries:
```sql
UPDATE `creature` SET `spawndist`=0, `MovementType`=0 WHERE `guid`= 75414;
UPDATE `creature_template` SET `ScriptName` = 'mob_sunfury_warlock' WHERE `creature_template`.`entry` = 21503;

UPDATE creature SET position_x = '-3821.350098', position_y = '388.109009', position_z = '120.563004', orientation = '3.462162' WHERE guid = '75409';
UPDATE creature SET position_x = '-3824.939941', position_y = '374.354004', position_z = '120.572998', orientation = '2.276190' WHERE guid = '75408';
UPDATE creature SET position_x = '-3841.300049', position_y = '376.158997', position_z = '120.410004', orientation = '0.783461' WHERE guid = '75414';
UPDATE creature SET position_x = '-3844.830078', position_y = '388.716003', position_z = '120.417999', orientation = '5.906568' WHERE guid = '75411';
UPDATE creature SET position_x = '-3840.110107', position_y = '403.463989', position_z = '120.544998', orientation = '5.052265' WHERE guid = '75410';
UPDATE creature SET position_x = '-3833.280029', position_y = '384.148010', position_z = '120.570999', orientation = '4.680910' WHERE guid = '28167';
```

Tested locally