### PR TITLE
Make KilJaeden Killable and allow further progress after Felmyst

### DIFF
--- a/src/scripts/scripts/zone/sunwell_plateau/instance_sunwell_plateau.cpp
+++ b/src/scripts/scripts/zone/sunwell_plateau/instance_sunwell_plateau.cpp
@@ -292,9 +292,9 @@ struct instance_sunwell_plateau : public ScriptedInstance
             case 188421: ForceField     = gobj->GetGUID(); break;
             case 188523: Collision_1    = gobj->GetGUID(); break;
             case 188524: Collision_2    = gobj->GetGUID(); break;
-            case 188075: 
-                //FireBarrier    = gobj->GetGUID();
-                if(GetData(DATA_FELMYST_EVENT) == DONE) {
+            case 188075: FireBarrier    = gobj->GetGUID();
+                if(GetData(DATA_FELMYST_EVENT) == DONE) 
+                {
                     HandleGameObject(FireBarrier, OPEN);
                 }
                 else 


### PR DESCRIPTION
Activate FireBarrier after Felmyst is killed (After Felymst is killed)

Implement Dummy Spell from TrinityCore3.3.5a
Summarize Enum/Define
Implement Aggro Range
Remove Script Spawned Pre Fight Adds, as this way of scripting
Encounters only brings issues, see Leotheras, Akama
Adjust Timers to TrinityCore3.3.5a
Fix some Text Sounds not being able to be heared by Players due to
UnitFlags/Invisibilty
Port some Flags to Database, where they belong
Let DB Handle Hand of the Deceiver Respawn, Linking.
Kill Kiljaeden Trigger on Kill (like Aran Blizzard, infight bug etc)
Port Spelltimers for Hand of the Deceiver(HotD) from ACID and Improve
OOC Channeling Behavior
Remove alot unneeded / out commented code which can be handled by the
Database
Make HP Threshold Check for HotD more readable
Implement SPELL_FELFIRE_PORTAL
Port mob_felfire_portalAI to Database as its just one passive Spell
which can be handled by ACID EAI.

DB Part is currently only in the Zone Issue.