### PR TITLE
Nethermancer Sepethrea Leashing

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3207,7 +3207,10 @@ void SpellMgr::LoadSpellCustomAttr()
                break;
             case 15453: // Arcane Explosion 
                 spellInfo->EffectBasePoints[0] = 154; 
-                break;            
+                break;
+            case 45195: // Frost Attack (Nethermancer Sepethrea)
+                spellInfo->EffectBasePoints[1] = -51;
+                break;
             case 40447: // BT: Akama - Soul Channel
                 spellInfo->Effect[0] = 0;
                 break;

--- a/src/scripts/scripts/zone/sunwell_plateau/instance_sunwell_plateau.cpp
+++ b/src/scripts/scripts/zone/sunwell_plateau/instance_sunwell_plateau.cpp
@@ -292,9 +292,9 @@ struct instance_sunwell_plateau : public ScriptedInstance
             case 188421: ForceField     = gobj->GetGUID(); break;
             case 188523: Collision_1    = gobj->GetGUID(); break;
             case 188524: Collision_2    = gobj->GetGUID(); break;
-            case 188075: 
-                //FireBarrier    = gobj->GetGUID();
-                if(GetData(DATA_FELMYST_EVENT) == DONE) {
+            case 188075: FireBarrier    = gobj->GetGUID();
+                if(GetData(DATA_FELMYST_EVENT) == DONE) 
+                {
                     HandleGameObject(FireBarrier, OPEN);
                 }
                 else 


### PR DESCRIPTION
- Introduced Enum to her and her adds
- Added Aggro Range as its slightly off

- Added Leashing Range as she should reset if pulled to far from her room.

Nethermancer Sepethrea encounter resets if she is pulled out of her room, and can no longer be kited to Pathaleons room.
http://wowwiki.wikia.com/wiki/Patch_2.1.0_(undocumented_changes)

- General Formating
- Adjusted Timers for RagingFlames
- Added unused nh version of Inferno (doesnt trigger periodically if cast)
- Moved Spell School Immunity to DB
- Moved Speed Values to DB for easier adjustments (changed patchwise)
- Changed nonblizzlike summon text to blizzlike resummon text after 15min when adds despawn (spellsummoned with duration)

- Increase Slow Amount of Nethermancer Sepethrea's Frost Attack

Nethermancer Sepethrea's Frost Attack now reduces movement speed by 25%
rather than 50%.
http://wowwiki.wikia.com/wiki/Patch_2.3.0