### PR TITLE
Basic instance timing implementation

### DIFF
--- a/sql/updates/chars/005_instance_times.sql
+++ b/sql/updates/chars/005_instance_times.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `instance_times` (
+  `instance_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `map` int(11) unsigned DEFAULT '0',
+  `difficulty` tinyint(1) unsigned DEFAULT NULL,
+  `data` longtext,
+  `start_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `end_time` timestamp NULL DEFAULT NULL,
+  `player_ids` longtext,
+  `deaths` int(11) DEFAULT '0',
+  PRIMARY KEY (`instance_id`),
+  KEY `map` (`map`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/game/InstanceData.h
+++ b/src/game/InstanceData.h
@@ -104,10 +104,10 @@ class LOOKING4GROUP_IMPORT_EXPORT InstanceData : public ZoneScript
         virtual void ResetEncounterInProgress();
 
         //Called when a player successfully enters the instance.
-        virtual void OnPlayerEnter(Player *) {}
+        void OnPlayerEnter(Player *);
 
         //Called when a player deaths in the instance.
-        virtual void OnPlayerDeath(Player *) {}
+        void OnPlayerDeath(Player *);
 
         //Called on creature death (after CreatureAI::JustDied)
         virtual void OnCreatureDeath(Creature *) {}

--- a/src/game/InstanceData.h
+++ b/src/game/InstanceData.h
@@ -104,10 +104,10 @@ class LOOKING4GROUP_IMPORT_EXPORT InstanceData : public ZoneScript
         virtual void ResetEncounterInProgress();
 
         //Called when a player successfully enters the instance.
-        void OnPlayerEnter(Player *);
+        virtual void OnPlayerEnter(Player *player);
 
         //Called when a player deaths in the instance.
-        void OnPlayerDeath(Player *);
+        virtual void OnPlayerDeath(Player *player);
 
         //Called on creature death (after CreatureAI::JustDied)
         virtual void OnCreatureDeath(Creature *) {}
@@ -148,7 +148,6 @@ class LOOKING4GROUP_IMPORT_EXPORT InstanceData : public ZoneScript
     private:
         std::vector<BossInfo> bosses;
         DoorInfoMap doors;
-
 
         virtual void OnObjectCreate(GameObject *) {}
         virtual void OnCreatureCreate(Creature *, uint32 entry) {}


### PR DESCRIPTION
## Features
* Applies to all instances with a script (most dungeons, raids etc) (Underbog is a known exception, there are likely otherwise - all important raids have a script which is typically what this will be used for... for now)
* Starts a timer when the first player enters aninstance
* Subsequent entries to the instances record the player ID
* Player deaths in an instance increment it's associated "death counter"
* When all bosses have been killed the timer is stopped (optional boss in Karazhan is *not* required)

```c            
            // Allow skipping of Karazhan optional Boss
            if (instance->GetId() == 532 && count == 4)
            {
                break;   
            }
```

### Important : there is an assumption that raid IDs are *unique* even after instance resets, weekly resets and so forth.

Tested fairly thoroughly locally, didn't notice any adverse affects. Would recommend testing locally and on PTR if at all possible.
Further contributions/improvements are welcome.