### PR TITLE
Fix extractor compilation on Linux

### DIFF
--- a/tools/extractor/System.cpp
+++ b/tools/extractor/System.cpp
@@ -18,7 +18,8 @@
 #include "loadlib/wdt.h"
 #include <fcntl.h>
 
-#if defined( __GNUC__ )
+#if defined( __unix__ )
+    #include <unistd.h>
     #define _open   open
     #define _close close
     #ifndef O_BINARY


### PR DESCRIPTION
Makes the DBC and Map extractor able to compile on Linux.