### PR TITLE
Fixed SQL updating instance end time

### DIFF
--- a/src/game/InstanceData.cpp
+++ b/src/game/InstanceData.cpp
@@ -55,7 +55,7 @@ void InstanceData::SaveToDB()
 
     if (instanceComplete)
     {
-        RealmDataDatabase.PExecute("UPDATE `instance_times` SET `end_time` = CURTIME() WHERE `instance_id` = %i", instance->GetInstanceId());
+        RealmDataDatabase.PExecute("UPDATE `instance_times` SET `end_time` = NOW() WHERE `instance_id` = %i", instance->GetInstanceId());
     }
 
     static SqlStatementID updateInstance;


### PR DESCRIPTION
`CURTIME()` to `NOW()`
Should address any issues in how timestamps are seemingly handled slightly differently depending on SQL version.