### PR TITLE
Fix VMap Tools Compilation

### DIFF
--- a/tools/libmpq/config.h
+++ b/tools/libmpq/config.h
@@ -1,0 +1,1 @@
+#define VERSION "0.4.2"

--- a/tools/vmap_assembler/CMakeLists.txt
+++ b/tools/vmap_assembler/CMakeLists.txt
@@ -23,49 +23,52 @@ ADD_DEFINITIONS("-O3")
 
 include_directories(../../src/shared)
 include_directories(../../src/game/vmap/)
-include_directories(../../dep/include/g3dlite/)
+include_directories(../../dep/include/)
 include_directories(../../dep/ACE_wrappers/)
 include_directories(../../objdir/dep/ACE_wrappers)
 include_directories(../../src/framework/)
 
-add_library(g3dlite ../../dep/src/g3dlite/AABox.cpp
-	../../dep/src/g3dlite/Box.cpp
-	../../dep/src/g3dlite/Crypto.cpp
-	../../dep/src/g3dlite/format.cpp
-	../../dep/src/g3dlite/Matrix3.cpp
-	../../dep/src/g3dlite/Plane.cpp
-	../../dep/src/g3dlite/System.cpp
-	../../dep/src/g3dlite/Triangle.cpp
-	../../dep/src/g3dlite/Vector3.cpp
-	../../dep/src/g3dlite/Vector4.cpp
-	../../dep/src/g3dlite/debugAssert.cpp
-	../../dep/src/g3dlite/fileutils.cpp
-	../../dep/src/g3dlite/g3dmath.cpp
-	../../dep/src/g3dlite/g3dfnmatch.cpp
-	../../dep/src/g3dlite/prompt.cpp
-	../../dep/src/g3dlite/stringutils.cpp
-	../../dep/src/g3dlite/Any.cpp
-	../../dep/src/g3dlite/BinaryFormat.cpp
-	../../dep/src/g3dlite/BinaryInput.cpp
-	../../dep/src/g3dlite/BinaryOutput.cpp
-	../../dep/src/g3dlite/Capsule.cpp
-	../../dep/src/g3dlite/CollisionDetection.cpp
-	../../dep/src/g3dlite/CoordinateFrame.cpp
-	../../dep/src/g3dlite/Cylinder.cpp
-	../../dep/src/g3dlite/Line.cpp
-	../../dep/src/g3dlite/LineSegment.cpp
-	../../dep/src/g3dlite/Log.cpp
-	../../dep/src/g3dlite/Matrix4.cpp
-	../../dep/src/g3dlite/MemoryManager.cpp
-	../../dep/src/g3dlite/Quat.cpp
-	../../dep/src/g3dlite/Random.cpp
-	../../dep/src/g3dlite/Ray.cpp
-	../../dep/src/g3dlite/ReferenceCount.cpp
-	../../dep/src/g3dlite/Sphere.cpp
-	../../dep/src/g3dlite/TextInput.cpp
-	../../dep/src/g3dlite/TextOutput.cpp
-	../../dep/src/g3dlite/UprightFrame.cpp
-	../../dep/src/g3dlite/Vector2.cpp
+add_library(g3dlite ../../dep/g3dlite/source/AABox.cpp
+	../../dep/g3dlite/source/Box.cpp
+	../../dep/g3dlite/source/Crypto.cpp
+	../../dep/g3dlite/source/format.cpp
+	../../dep/g3dlite/source/Matrix3.cpp
+	../../dep/g3dlite/source/Plane.cpp
+	../../dep/g3dlite/source/System.cpp
+	../../dep/g3dlite/source/Triangle.cpp
+	../../dep/g3dlite/source/Vector3.cpp
+	../../dep/g3dlite/source/Vector4.cpp
+	../../dep/g3dlite/source/debugAssert.cpp
+	../../dep/g3dlite/source/FileSystem.cpp
+	../../dep/g3dlite/source/fileutils.cpp
+	../../dep/g3dlite/source/g3dmath.cpp
+	../../dep/g3dlite/source/g3dfnmatch.cpp
+	../../dep/g3dlite/source/prompt.cpp
+	../../dep/g3dlite/source/stringutils.cpp
+	../../dep/g3dlite/source/Any.cpp
+	../../dep/g3dlite/source/BinaryFormat.cpp
+	../../dep/g3dlite/source/BinaryInput.cpp
+	../../dep/g3dlite/source/BinaryOutput.cpp
+	../../dep/g3dlite/source/Capsule.cpp
+	../../dep/g3dlite/source/CollisionDetection.cpp
+	../../dep/g3dlite/source/CoordinateFrame.cpp
+	../../dep/g3dlite/source/Cylinder.cpp
+	../../dep/g3dlite/source/Line.cpp
+	../../dep/g3dlite/source/LineSegment.cpp
+	../../dep/g3dlite/source/Log.cpp
+	../../dep/g3dlite/source/Matrix4.cpp
+	../../dep/g3dlite/source/MemoryManager.cpp
+	../../dep/g3dlite/source/PhysicsFrame.cpp
+	../../dep/g3dlite/source/Quat.cpp
+	../../dep/g3dlite/source/Random.cpp
+	../../dep/g3dlite/source/uint128.cpp
+	../../dep/g3dlite/source/Ray.cpp
+	../../dep/g3dlite/source/ReferenceCount.cpp
+	../../dep/g3dlite/source/Sphere.cpp
+	../../dep/g3dlite/source/TextInput.cpp
+	../../dep/g3dlite/source/TextOutput.cpp
+	../../dep/g3dlite/source/UprightFrame.cpp
+	../../dep/g3dlite/source/Vector2.cpp
 	)
 
 add_library(vmap

--- a/tools/vmap_extractor_v3/CMakeLists.txt
+++ b/tools/vmap_extractor_v3/CMakeLists.txt
@@ -20,6 +20,4 @@ ADD_DEFINITIONS("-Wall")
 ADD_DEFINITIONS("-ggdb")
 ADD_DEFINITIONS("-O3")
 
-include_directories(../../dep/libmpq)
-
 add_subdirectory(vmapextract)

--- a/tools/vmap_extractor_v3/vmapextract/CMakeLists.txt
+++ b/tools/vmap_extractor_v3/vmapextract/CMakeLists.txt
@@ -11,6 +11,19 @@
 cmake_minimum_required (VERSION 2.6)
 project (MANGOS_IOMAP_EXTRACTOR)
 
-LINK_DIRECTORIES( ${LINK_DIRECTORIES} ../../../dep/libmpq/libmpq/.libs/ )
+include_directories(
+     ../../libmpq
+     ../../libmpq/libmpq
+)
+
+add_library(libmpq
+     ../../libmpq/libmpq/common.c
+     ../../libmpq/libmpq/extract.c
+     ../../libmpq/libmpq/explode.c
+     ../../libmpq/libmpq/wave.c
+     ../../libmpq/libmpq/huffman.c
+     ../../libmpq/libmpq/mpq.c
+)
+
 add_executable(vmapextractor adtfile.cpp  dbcfile.cpp  model.cpp  mpq_libmpq.cpp  vmapexport.cpp  wdtfile.cpp  wmo.cpp)
-target_link_libraries(vmapextractor libmpq.a bz2 z)
+target_link_libraries(vmapextractor libmpq bz2 z)


### PR DESCRIPTION
Allows VMap extractor and VMap assembler to compile using CMake.

Bug: On Linux, when the vmap extractor finishes creating .wmo files it crashes with a memory error.
GDB Backtrace: `#0  0x00007ffff6d8f670 in raise () from /usr/lib/libc.so.6
#1  0x00007ffff6d90d00 in abort () from /usr/lib/libc.so.6
#2  0x00007ffff76bbfd5 in __gnu_cxx::__verbose_terminate_handler () at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00007ffff76b9be6 in __cxxabiv1::__terminate (handler=<optimized out>) at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:47
#4  0x00007ffff76b9c31 in std::terminate () at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:57
#5  0x00007ffff76b9e73 in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7ffff79a5750 <typeinfo for std::bad_alloc>, dest=0x7ffff76b7ed0 <std::bad_alloc::~bad_alloc()>) at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/eh_throw.cc:93
#6  0x00007ffff76ba3dc in operator new (sz=sz@entry=38749949616) at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/new_op.cc:54
#7  0x00007ffff76ba445 in operator new[] (sz=sz@entry=38749949616) at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/new_opv.cc:32
#8  0x0000000000406ad0 in Model::open (this=this@entry=0x7fffffffd030) at /home/Looking4Group/L4G_Core/tools/vmap_extractor_v3/vmapextract/model.cpp:49
#9  0x000000000040628f in ADTFile::init (this=this@entry=0x735410, map_num=0, tileX=tileX@entry=27, tileY=tileY@entry=29) at /home/Looking4Group/L4G_Core/tools/vmap_extractor_v3/vmapextract/adtfile.cpp:152
#10 0x0000000000407b1b in ParsMapFiles () at /home/Looking4Group/L4G_Core/tools/vmap_extractor_v3/vmapextract/vmapexport.cpp:235
#11 0x000000000040484f in main (argc=<optimized out>, argv=<optimized out>) at /home/Looking4Group/L4G_Core/tools/vmap_extractor_v3/vmapextract/vmapexport.cpp:520
`