### PR TITLE
Archimonde Prenerf Soul Charge Silence

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3962,6 +3962,9 @@ void SpellMgr::LoadSpellCustomAttr()
             case 30564: // Worgen's Spite has a duration of 1.1 seconds (Will fade once Transform fades)
                 spellInfo->DurationIndex = DURATION_MAX_1_1_SEC_1;
                 break;
+            case 32053: // Soul Charge (Archimonde)
+                spellInfo->DurationIndex = DURATION_MAX_6_SEC;
+                break;
             case 38759: // Dark Shell (Pandemonious HC)
                 spellInfo->DurationIndex = DURATION_MAX_8_SEC;
                 break;


### PR DESCRIPTION
is silenced or takes 50% more damage for 6 seconds

http://wowwiki.wikia.com/wiki/Archimonde_(tactics)?oldid=824048

---

Archimonde's Soul Charge silence has been lowered in duration to 4 seconds, and the death of the Priest with Spirit of Redemption will no longer create two Soul Charges.

http://wowwiki.wikia.com/wiki/Patch_2.2.0