### PR TITLE
Core/Spell Gruul Shatter Damage

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3772,9 +3772,9 @@ void SpellMgr::LoadSpellCustomAttr()
                 spellInfo->Dispel = DISPEL_NONE;
                 spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
                 break;
-            case 33671: // Gruul Shatter Radius Reduction (From 20 to 19 yards)
+            case 33671: // Gruul Shatter Radius Reduction (From 20 to 18 yards)
                 // There was a slight range issue with shatter
-                spellInfo->EffectRadiusIndex[0] = 49;
+                spellInfo->EffectRadiusIndex[0] = EFFECT_RADIUS_18_YARDS;
                 break;
             case 30567: // Tormet of worgen has 3% chance to proc Torment of the Worgen (Transform)
                 spellInfo->procChance = 3;


### PR DESCRIPTION
didnt deal damage anymore as 49 defined = EFFECT_RADIUS_90_YARDS

* there is no EffectRadiusIndex for 19y so i took 18yards.

---


![unbenannt](https://user-images.githubusercontent.com/19734826/27880147-4191314c-61c4-11e7-8a91-348b0ba886d1.PNG)

deals damage again.