### PR TITLE
Core/Script: Tryfix Edgecase Shade of Akama Evade

### DIFF
--- a/src/scripts/scripts/zone/black_temple/boss_shade_of_akama.cpp
+++ b/src/scripts/scripts/zone/black_temple/boss_shade_of_akama.cpp
@@ -269,6 +269,7 @@ struct boss_shade_of_akamaAI : public ScriptedAI
 
         me->SetHealth(me->GetMaxHealth());
         DespawnChannelersAndSorcerers();
+        me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
 
         if (Unit *owner = me->GetCharmerOrOwner())
         {
@@ -311,6 +312,7 @@ struct boss_shade_of_akamaAI : public ScriptedAI
 
         me->SetSpeed(MOVE_WALK, 1);
         me->SetSpeed(MOVE_RUN, 1);
+        me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
 
         if (Creature *akama = me->GetCreature(*me, AkamaGUID))
         {


### PR DESCRIPTION
Case: 

* Shade of Akama kills Akama, attempts Home Movement.
* he is somehow stopped (maybe damage and still attackable)
* HomeMoveGen breaks, Boss doesnt reset properly, Encounter Broken and Shade is just killable

Couldnt reproduce this locally, hope that this can fix this edgecase.